### PR TITLE
Fast function map

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -62,10 +62,22 @@ include("functionmap.jl") # using a function as linear map
 
 LinearMap{T}(A::Union{AbstractMatrix{T},AbstractLinearMap{T}};isreal::Bool=Base.isreal(A),issym::Bool=Base.issym(A),ishermitian::Bool=Base.ishermitian(A),isposdef::Bool=Base.isposdef(A)) =
     WrappedMap(A;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef)
-LinearMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing) =
-    FunctionMap(f,M,N;ismutating=ismutating,isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
-LinearMap(f::Function,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing) =
-    FunctionMap{eltype}(f,M,N;ismutating=ismutating,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
 
+function LinearMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,
+        issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+    if ismutating
+        MutatingFunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+    else
+        FunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+    end
+end
 
+function LinearMap(f::Function,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,
+        ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+    if ismutating
+        FunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+    else
+        FunctionMap{eltype}(f,M,N; issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+    end
+end
 end # module

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -63,7 +63,7 @@ include("functionmap.jl") # using a function as linear map
 LinearMap{T}(A::Union{AbstractMatrix{T},AbstractLinearMap{T}};isreal::Bool=Base.isreal(A),issym::Bool=Base.issym(A),ishermitian::Bool=Base.ishermitian(A),isposdef::Bool=Base.isposdef(A)) =
     WrappedMap(A;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef)
 
-function LinearMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,
+function LinearMap(f,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,
         issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
     if ismutating
         MutatingFunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
@@ -72,7 +72,7 @@ function LinearMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bo
     end
 end
 
-function LinearMap(f::Function,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,
+function LinearMap(f,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,
         ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
     if ismutating
         FunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -75,7 +75,7 @@ end
 function LinearMap(f,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,
         ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
     if ismutating
-        FunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+        FunctionMap{eltype}(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
     else
         FunctionMap{eltype}(f,M,N; issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
     end

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -64,7 +64,7 @@ LinearMap{T}(A::Union{AbstractMatrix{T},AbstractLinearMap{T}};isreal::Bool=Base.
     WrappedMap(A;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef)
 
 function LinearMap(f,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,
-        issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+        issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
     if ismutating
         MutatingFunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
     else
@@ -73,7 +73,7 @@ function LinearMap(f,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,
 end
 
 function LinearMap(f,eltype::Type,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,
-        ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+        ishermitian::Bool=(eltype<:Real && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
     if ismutating
         FunctionMap(f,M,N;isreal=isreal,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
     else

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -1,28 +1,31 @@
 typealias OptionalFunction Union{Base.Callable,Void}
 
-immutable FunctionMap{T}<:AbstractLinearMap{T}
-    f::Function
+immutable FunctionMap{T, F, Ft, Fc}<:AbstractLinearMap{T}
+    f::F
     M::Int
     N::Int
     _ismutating::Bool
     _issym::Bool
     _ishermitian::Bool
     _isposdef::Bool
-    _fT::OptionalFunction
-    _fC::OptionalFunction
-    function FunctionMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+    _fT::Ft
+    _fC::Fc
+    function FunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;ismutating::Bool=false,issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
         # sanity checks
         (issym || ishermitian || isposdef) && (M!=N) && error("a symmetric or hermitian map should be square")
         T<:Real && (issym!=ishermitian) && error("a real symmetric map is also hermitian")
         isposdef && !ishermitian && error("a positive definite map should be hermitian")
         # construct
-        new(f,M,N,ismutating,issym,ishermitian,isposdef,ftranspose,fctranspose)
+        new(f, M, N, ismutating, issym, ishermitian, isposdef, ftranspose, fctranspose)
     end
 end
 # additional constructor
-function FunctionMap(f::Function,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose::OptionalFunction=nothing,fctranspose::OptionalFunction=nothing)
+function FunctionMap(f,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
     T=(isreal ? Float64 : Complex128) # default assumption
-    FunctionMap{T}(f,M,N;ismutating=ismutating,issym=issym,ishermitian=ishermitian,isposdef=isposdef,ftranspose=ftranspose,fctranspose=fctranspose)
+    F = typeof(f)
+    Ft = typeof(ftranspose)
+    Fc = typeof(fctranspose)
+    FunctionMap{T, F, Ft, Fc}(f,M,N, ftranspose, fctranspose;ismutating=ismutating,issym=issym,ishermitian=ishermitian,isposdef=isposdef)
 end
 
 # show

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -98,132 +98,124 @@ end
 
 # At_mul_B!
 function Base.At_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
-    A._issym && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     copy!(y, A._fT(x))
 end
 
 function Base.At_mul_B!{T,F,Fc}(y::AbstractVector, A::FunctionMap{T,F,Void,Fc}, x::AbstractVector)
-    A._issym && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     copy!(y, conj(A._fC(conj(x))))
 end
 
 function Base.At_mul_B!{T,F}(y::AbstractVector,A::FunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._issym && return Base.A_mul_B!(y,A,x)
     error("transpose not implemented for $A")
 end
 
 function Base.At_mul_B!(y::AbstractVector,A::MutatingFunctionMap,x::AbstractVector)
-    A._issym && return Base.A_mul_B!(y,A,x)
     (length(x) == A.M && length(y) == A.N) || throw(DimensionMismatch())
     A._fT(y,x)
 end
 
 function Base.At_mul_B!{T,F,Fc}(y::AbstractVector,A::MutatingFunctionMap{T,F,Void,Fc},x::AbstractVector)
-    A._issym && return Base.A_mul_B!(y,A,x)
     (length(x) == A.M && length(y) == A.N) || throw(DimensionMismatch())
     conj!(A._fC(y, conj(x)))
 end
 
 function Base.At_mul_B!{T,F}(y::AbstractVector,A::MutatingFunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._issym && return Base.A_mul_B!(y,A,x)
     error("transpose not implemented for $A")
 end
 
 # At_mul_B
 function Base.At_mul_B(A::FunctionMap,x::AbstractVector)
-    A._issym && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     A._fT(x)
 end
 
 function Base.At_mul_B{T,F,Fc}(A::FunctionMap{T,F,Void,Fc},x::AbstractVector)
-    A._issym && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     conj(A._fC(conj(x)))
 end
 
 function Base.At_mul_B{T,F}(A::FunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._issym && return A*x
     error("transpose not implemented for $A")
 end
 
 function Base.At_mul_B(A::MutatingFunctionMap,x::AbstractVector)
-    A._issym && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),x)
 end
 
 function Base.At_mul_B{T,F,Fc}(A::MutatingFunctionMap{T,F,Void,Fc},x::AbstractVector)
-    A._issym && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     conj!(A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x)))
 end
 
 function Base.At_mul_B{T,F}(A::MutatingFunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._issym && return A*x
     error("transpose not implemented for $A")
 end
 
 # Ac_mul_B!
 function Base.Ac_mul_B!(y::AbstractVector,A::FunctionMap,x::AbstractVector)
-    A._ishermitian && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     copy!(y,A._fC(x))
 end
 
 function Base.Ac_mul_B!{T,F,Ft}(y::AbstractVector,A::FunctionMap{T,F,Ft,Void},x::AbstractVector)
-    A._ishermitian && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     copy!(y,conj(A._fT(conj(x))))
 end
 
 function Base.Ac_mul_B!{T,F}(y::AbstractVector,A::FunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._ishermitian && return Base.A_mul_B!(y,A,x)
     error("ctranspose not implemented for $A")
 end
 
 function Base.Ac_mul_B!(y::AbstractVector,A::MutatingFunctionMap,x::AbstractVector)
-    A._ishermitian && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     A._fC(y,x)
 end
 
 function Base.Ac_mul_B!{T,F,Ft}(y::AbstractVector,A::MutatingFunctionMap{T,F,Ft,Void},x::AbstractVector)
-    A._ishermitian && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     conj!(A._fT(y, conj(x)))
 end
 
 function Base.Ac_mul_B!{T,F}(y::AbstractVector,A::MutatingFunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._ishermitian && return Base.A_mul_B!(y,A,x)
     error("ctranspose not implemented for $A")
 end
 
 # Ac_mul_B
 function Base.Ac_mul_B(A::FunctionMap,x::AbstractVector)
-    A._ishermitian && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     A._fC(x)
 end
 
 function Base.Ac_mul_B{T,F,Ft}(A::FunctionMap{T,F,Ft,Void},x::AbstractVector)
-    A._ishermitian && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     conj(A._fT(conj(x)))
 end
 
 function Base.Ac_mul_B{T,F}(A::FunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._ishermitian && return A*x
     error("ctranspose not implemented for $A")
 end
 
 function Base.Ac_mul_B(A::MutatingFunctionMap,x::AbstractVector)
-    A._ishermitian && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),x)
 end
 
 function Base.Ac_mul_B{T,F,Ft}(A::MutatingFunctionMap{T,F,Ft,Void},x::AbstractVector)
-    A._ishermitian && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     conj!(A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x)))
 end
 
 function Base.Ac_mul_B{T,F}(A::MutatingFunctionMap{T,F,Void,Void},x::AbstractVector)
+    A._ishermitian && return A*x
     error("ctranspose not implemented for $A")
 end

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -2,7 +2,7 @@ typealias OptionalFunction Union{Base.Callable,Void}
 
 abstract AbstractFunctionMap{T} <: AbstractLinearMap{T}
 
-function sanitycheck(isreal::Bool, issym::Bool, ishermitian::Bool, isposdef::Bool)
+function sanitycheck(M::Int, N::Int, isreal::Bool, issym::Bool, ishermitian::Bool, isposdef::Bool)
     (issym || ishermitian || isposdef) && (M!=N) && error("a symmetric or hermitian map should be square")
     isreal && (issym!=ishermitian) && error("a real symmetric map is also hermitian")
     isposdef && !ishermitian && error("a positive definite map should be hermitian")
@@ -18,7 +18,7 @@ immutable FunctionMap{T, F, Ft, Fc} <: AbstractFunctionMap{T}
     _fT::Ft
     _fC::Fc
     function FunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
-        sanitycheck(T<:Real, issym, ishermitian,isposdef)
+        sanitycheck(M, N, T<:Real, issym, ishermitian,isposdef)
         new(f, M, N, issym, ishermitian, isposdef, ftranspose, fctranspose)
     end
 end
@@ -42,7 +42,7 @@ immutable MutatingFunctionMap{T, F, Ft, Fc} <: AbstractFunctionMap{T}
     _fT::Ft
     _fC::Fc
     function MutatingFunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
-        checkproperties(T<:Real, issym, ishermitian,isposdef)
+        checkproperties(M, N, T<:Real, issym, ishermitian,isposdef)
         new(f, M, N, issym, ishermitian, isposdef, ftranspose, fctranspose)
     end
 end

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -1,97 +1,193 @@
 typealias OptionalFunction Union{Base.Callable,Void}
 
-immutable FunctionMap{T, F, Ft, Fc}<:AbstractLinearMap{T}
+abstract AbstractFunctionMap{T} <: AbstractLinearMap{T}
+
+function sanitycheck(isreal::Bool, issym::Bool, ishermitian::Bool, isposdef::Bool)
+    (issym || ishermitian || isposdef) && (M!=N) && error("a symmetric or hermitian map should be square")
+    isreal && (issym!=ishermitian) && error("a real symmetric map is also hermitian")
+    isposdef && !ishermitian && error("a positive definite map should be hermitian")
+end
+
+immutable FunctionMap{T, F, Ft, Fc} <: AbstractFunctionMap{T}
     f::F
     M::Int
     N::Int
-    _ismutating::Bool
     _issym::Bool
     _ishermitian::Bool
     _isposdef::Bool
     _fT::Ft
     _fC::Fc
-    function FunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;ismutating::Bool=false,issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
-        # sanity checks
-        (issym || ishermitian || isposdef) && (M!=N) && error("a symmetric or hermitian map should be square")
-        T<:Real && (issym!=ishermitian) && error("a real symmetric map is also hermitian")
-        isposdef && !ishermitian && error("a positive definite map should be hermitian")
-        # construct
-        new(f, M, N, ismutating, issym, ishermitian, isposdef, ftranspose, fctranspose)
+    function FunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
+        sanitycheck(T<:Real, issym, ishermitian,isposdef)
+        new(f, M, N, issym, ishermitian, isposdef, ftranspose, fctranspose)
     end
 end
+
 # additional constructor
-function FunctionMap(f,M::Int,N::Int=M;ismutating::Bool=false,isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
+function FunctionMap(f,M::Int,N::Int=M;isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
     T=(isreal ? Float64 : Complex128) # default assumption
     F = typeof(f)
     Ft = typeof(ftranspose)
     Fc = typeof(fctranspose)
-    FunctionMap{T, F, Ft, Fc}(f,M,N, ftranspose, fctranspose;ismutating=ismutating,issym=issym,ishermitian=ishermitian,isposdef=isposdef)
+    FunctionMap{T, F, Ft, Fc}(f,M,N, ftranspose, fctranspose;issym=issym,ishermitian=ishermitian,isposdef=isposdef)
 end
+
+immutable MutatingFunctionMap{T, F, Ft, Fc} <: AbstractFunctionMap{T}
+    f::F
+    M::Int
+    N::Int
+    _issym::Bool
+    _ishermitian::Bool
+    _isposdef::Bool
+    _fT::Ft
+    _fC::Fc
+    function MutatingFunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
+        checkproperties(T<:Real, issym, ishermitian,isposdef)
+        new(f, M, N, issym, ishermitian, isposdef, ftranspose, fctranspose)
+    end
+end
+
+function MutatingFunctionMap(f,M::Int,N::Int=M;isreal::Bool=true,issym::Bool=false,ishermitian::Bool=(isreal && issym),isposdef::Bool=false,ftranspose=nothing,fctranspose=nothing)
+    T=(isreal ? Float64 : Complex128) # default assumption
+    F = typeof(f)
+    Ft = typeof(ftranspose)
+    Fc = typeof(fctranspose)
+    MutatingFunctionMap{T, F, Ft, Fc}(f,M,N, ftranspose, fctranspose;issym=issym,ishermitian=ishermitian,isposdef=isposdef)
+end
+
 
 # show
 function Base.show{T}(io::IO,A::FunctionMap{T})
-    print(io,"FunctionMap{$T}($(A.f),$(A.M),$(A.N);ismutating=$(A._ismutating),issym=$(A._issym),ishermitian=$(A._ishermitian),isposdef=$(A._isposdef),transpose=$(A._fT),ctranspose=$(A._fC))")
+    print(io,"FunctionMap{$T}($(A.f),$(A.M),$(A.N);issym=$(A._issym),ishermitian=$(A._ishermitian),isposdef=$(A._isposdef),transpose=$(A._fT),ctranspose=$(A._fC))")
+end
+
+function Base.show{T}(io::IO,A::MutatingFunctionMap{T})
+    print(io,"MutatingFunctionMap{$T}($(A.f),$(A.M),$(A.N);issym=$(A._issym),ishermitian=$(A._ishermitian),isposdef=$(A._isposdef),transpose=$(A._fT),ctranspose=$(A._fC))")
 end
 
 
 # properties
-Base.size(A::FunctionMap,n)=(n==1 ? A.M : (n==2 ? A.N : error("AbstractLinearMap objects have only 2 dimensions")))
-Base.size(A::FunctionMap)=(A.M,A.N)
-Base.issym(A::FunctionMap)=A._issym
-Base.ishermitian(A::FunctionMap)=A._ishermitian
-Base.isposdef(A::FunctionMap)=A._isposdef
+Base.size(A::AbstractFunctionMap,n)=(n==1 ? A.M : (n==2 ? A.N : error("AbstractLinearMap objects have only 2 dimensions")))
+Base.size(A::AbstractFunctionMap)=(A.M,A.N)
+Base.issym(A::AbstractFunctionMap)=A._issym
+Base.ishermitian(A::AbstractFunctionMap)=A._ishermitian
+Base.isposdef(A::AbstractFunctionMap)=A._isposdef
 
 # multiplication with vector
 Base.A_mul_B!(y::AbstractVector,A::FunctionMap,x::AbstractVector)=begin
     (length(x)==A.N && length(y)==A.M) || throw(DimensionMismatch())
-    A._ismutating ? A.f(y,x) : copy!(y,A.f(x))
+    copy!(y,A.f(x))
     return y
 end
+
+Base.A_mul_B!(y::AbstractVector,A::MutatingFunctionMap,x::AbstractVector)=begin
+    (length(x)==A.N && length(y)==A.M) || throw(DimensionMismatch())
+    A.f(y,x)
+    return y
+end
+
 *(A::FunctionMap,x::AbstractVector)=begin
     length(x)==A.N || throw(DimensionMismatch())
-    A._ismutating ? A.f(similar(x,promote_type(eltype(A),eltype(x)),A.M),x) : A.f(x)
+    A.f(x)
 end
+
+*(A::MutatingFunctionMap,x::AbstractVector)=begin
+    length(x)==A.N || throw(DimensionMismatch())
+    A.f(similar(x, promote_type(eltype(A),eltype(x)), A.M), x)
+end
+
 
 Base.At_mul_B!(y::AbstractVector,A::FunctionMap,x::AbstractVector)=begin
     A._issym && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     if A._fT!=nothing
-        return (A._ismutating ? A._fT(y,x) : copy!(y,A._fT(x)))
+        copy!(y, A._fT(x))
     elseif A._fC!=nothing
-        return (A._ismutating ? conj!(A._fC(y,conj(x))) : copy!(y,conj(A._fC(conj(x)))))
+        copy!(y, conj(A._fC(conj(x))))
     else
         error("transpose not implemented for $A")
     end
 end
+
+Base.At_mul_B!(y::AbstractVector,A::MutatingFunctionMap,x::AbstractVector)=begin
+    A._issym && return Base.A_mul_B!(y,A,x)
+    (length(x) == A.M && length(y) == A.N) || throw(DimensionMismatch())
+    if A._fT != nothing
+        return A._fT(y,x)
+    elseif A._fC != nothing
+        return conj!(A._fC(y, conj(x)))
+    else
+        error("transpose not implemented for $A")
+    end
+end
+
 Base.At_mul_B(A::FunctionMap,x::AbstractVector)=begin
     A._issym && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     if A._fT!=nothing
-        return (A._ismutating ? A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),x) : A._fT(x))
+        return A._fT(x)
     elseif A._fC!=nothing
-        return (A._ismutating ? conj!(A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x))) : conj(A._fC(conj(x))))
+        return conj(A._fC(conj(x)))
     else
         error("transpose not implemented for $A")
     end
 end
+
+Base.At_mul_B(A::MutatingFunctionMap, x::AbstractVector)=begin
+    A._issym && return A*x
+    length(x)==A.M || throw(DimensionMismatch())
+    if A._fT!=nothing
+        return A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),x)
+    elseif A._fC!=nothing
+        return conj!(A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x)))
+    else
+        error("transpose not implemented for $A")
+    end
+end
+
 Base.Ac_mul_B!(y::AbstractVector,A::FunctionMap,x::AbstractVector)=begin
     A._ishermitian && return Base.A_mul_B!(y,A,x)
     (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
     if A._fC!=nothing
-        return (A._ismutating ? A._fC(y,x) : copy!(y,A._fC(x)))
+        return copy!(y,A._fC(x))
     elseif A._fT!=nothing
-        return (A._ismutating ? conj!(A._fT(y,conj(x))) : copy!(y,conj(A._fT(conj(x)))))
+        return copy!(y,conj(A._fT(conj(x))))
     else
         error("ctranspose not implemented for $A")
     end
 end
+
+Base.Ac_mul_B!(y::AbstractVector,A::MutatingFunctionMap,x::AbstractVector)=begin
+    A._ishermitian && return Base.A_mul_B!(y,A,x)
+    (length(x)==A.M && length(y)==A.N) || throw(DimensionMismatch())
+    if A._fC!=nothing
+        return A._fC(y,x)
+    elseif A._fT!=nothing
+        return conj!(A._fT(y, conj(x)))
+    else
+        error("ctranspose not implemented for $A")
+    end
+end
+
 Base.Ac_mul_B(A::FunctionMap,x::AbstractVector)=begin
     A._ishermitian && return A*x
     length(x)==A.M || throw(DimensionMismatch())
     if A._fC!=nothing
-        return (A._ismutating ? A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),x) : A._fC(x))
+        return A._fC(x)
     elseif A._fT!=nothing
-        return (A._ismutating ? conj!(A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x))) : conj(A._fT(conj(x))))
+        return conj(A._fT(conj(x)))
+    else
+        error("ctranspose not implemented for $A")
+    end
+end
+
+Base.Ac_mul_B(A::MutatingFunctionMap,x::AbstractVector)=begin
+    A._ishermitian && return A*x
+    length(x)==A.M || throw(DimensionMismatch())
+    if A._fC!=nothing
+        return A._fC(similar(x,promote_type(eltype(A),eltype(x)),A.N),x)
+    elseif A._fT!=nothing
+        return conj!(A._fT(similar(x,promote_type(eltype(A),eltype(x)),A.N),conj(x)))
     else
         error("ctranspose not implemented for $A")
     end

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -42,7 +42,7 @@ immutable MutatingFunctionMap{T, F, Ft, Fc} <: AbstractFunctionMap{T}
     _fT::Ft
     _fC::Fc
     function MutatingFunctionMap(f,M::Int,N::Int=M, ftranspose=nothing,fctranspose=nothing;issym::Bool=false,ishermitian::Bool=(T<:Real && issym),isposdef::Bool=false)
-        checkproperties(M, N, T<:Real, issym, ishermitian,isposdef)
+        sanitycheck(M, N, T<:Real, issym, ishermitian,isposdef)
         new(f, M, N, issym, ishermitian, isposdef, ftranspose, fctranspose)
     end
 end


### PR DESCRIPTION
This pull request makes linear mappings type stable in julia 0.5 and when using the [Fast Anonymous](https://github.com/timholy/FastAnonymous.jl) package.
In order to do so, it splits the current `FunctionMap` type into `FunctionMap` and `MutatingFunctionMap` with common parent `AbstractFunctionMap`. This allows to use dispatch to chose the right multiplication method.
Contrary to the current solution, `issym` and `ishermitian` is only employed when `ftranspose` and `ctranspose` are not set. This was necessary to enforce type stability, but I believe it is also quite sensible.
