### PR TITLE
Fallback options when complement function is not available

### DIFF
--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -16,6 +16,11 @@ FunctionMap{T}(f, fc, M::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, f
 
 function FunctionMap{T,F1,F2}(f::F1, fc::F2, M::Int, N::Int, ::Type{T} = Float64;
     ismutating::Bool = false, issymmetric::Bool = false, ishermitian::Bool=(T<:Real && issymmetric), isposdef::Bool = false)
+
+    if fc == nothing
+        warn("transpose not implemented for the map")
+    end
+
     FunctionMap{T,F1,F2}(f, fc, M, N, ismutating, issymmetric, ishermitian, isposdef)
 end
 
@@ -61,7 +66,8 @@ function Base.At_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
         end
         return y
     else
-        error("transpose not implemented for $A")
+        copy!(y, full(A)'*x)
+        return y
     end
 end
 function Base.At_mul_B(A::FunctionMap, x::AbstractVector)
@@ -82,7 +88,9 @@ function Base.At_mul_B(A::FunctionMap, x::AbstractVector)
         end
         return y
     else
-        error("transpose not implemented for $A")
+        y = similar(x, promote_type(eltype(A), eltype(x)), A.N)
+        copy!(y, full(A)'*x)
+        return y
     end
 end
 
@@ -92,7 +100,8 @@ function Base.Ac_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
     if A.fc != nothing
         return (ismutating(A) ? A.fc(y, x) : copy!(y, A.fc(x)))
     else
-        error("ctranspose not implemented for $A")
+        copy!(y, full(A)'*x)
+        return y
     end
 end
 function Base.Ac_mul_B(A::FunctionMap, x::AbstractVector)
@@ -107,6 +116,8 @@ function Base.Ac_mul_B(A::FunctionMap, x::AbstractVector)
         end
         return y
     else
-        error("ctranspose not implemented for $A")
+        y = similar(x, promote_type(eltype(A), eltype(x)), A.N)
+        copy!(y, full(A)'*x)
+        return y
     end
 end

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -3,6 +3,7 @@ immutable FunctionMap{T,F1,F2}<:AbstractLinearMap{T}
     fc::F2
     M::Int
     N::Int
+    X::Array{T,2}
     _ismutating::Bool
     _issymmetric::Bool
     _ishermitian::Bool
@@ -10,23 +11,29 @@ immutable FunctionMap{T,F1,F2}<:AbstractLinearMap{T}
 end
 
 # additional constructor
-FunctionMap{T}(f, M::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, nothing, M, M, T; kwargs...)
-FunctionMap{T}(f, M::Int, N::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, nothing, M, N, T; kwargs...)
-FunctionMap{T}(f, fc, M::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, fc, M, M, T; kwargs...)
+FunctionMap{T}(f, M::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, nothing, M, M, zeros(T, M, M), T; kwargs...)
+FunctionMap{T}(f, M::Int, N::Int, ::Type{T} = Float64; kwargs...) = FunctionMap(f, nothing, M, N, zeros(T, M, M), T; kwargs...)
+FunctionMap{T}(f, fc, M::Int, nothing, ::Type{T} = Float64; kwargs...) = FunctionMap(f, fc, M, M, zeros(T, M, M), T; kwargs...)
 
-function FunctionMap{T,F1,F2}(f::F1, fc::F2, M::Int, N::Int, ::Type{T} = Float64;
+function FunctionMap{T,F1,F2}(f::F1, fc::F2, M::Int, N::Int, X::Array{T, 2}, ::Type{T} = Float64;
     ismutating::Bool = false, issymmetric::Bool = false, ishermitian::Bool=(T<:Real && issymmetric), isposdef::Bool = false)
-
     if fc == nothing
+        X = zeros(T, (M, N))
+        v = zeros(T, N)
+        for i=1:N
+            v[i] = one(T)
+            ismutating? f(view(X,:,i), v) : copy!(view(X,:,i), f(v))
+            v[i] = zero(T)
+        end
         warn("transpose not implemented for the map")
     end
 
-    FunctionMap{T,F1,F2}(f, fc, M, N, ismutating, issymmetric, ishermitian, isposdef)
+    FunctionMap{T,F1,F2}(f, fc, M, N, X, ismutating, issymmetric, ishermitian, isposdef)
 end
 
 # show
 function Base.show{T}(io::IO,A::FunctionMap{T})
-    print(io,"FunctionMap{$T}($(A.f), $(A.fc), $(A.M), $(A.N); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
+    print(io,"FunctionMap{$T}($(A.f), $(A.fc), $(A.M), $(A.N), $(A.X); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
 end
 
 # properties
@@ -66,7 +73,7 @@ function Base.At_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
         end
         return y
     else
-        copy!(y, full(A)'*x)
+        copy!(y, (A.X)'*x)
         return y
     end
 end
@@ -89,7 +96,7 @@ function Base.At_mul_B(A::FunctionMap, x::AbstractVector)
         return y
     else
         y = similar(x, promote_type(eltype(A), eltype(x)), A.N)
-        copy!(y, full(A)'*x)
+        copy!(y, (A.X)'*x)
         return y
     end
 end
@@ -100,7 +107,7 @@ function Base.Ac_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
     if A.fc != nothing
         return (ismutating(A) ? A.fc(y, x) : copy!(y, A.fc(x)))
     else
-        copy!(y, full(A)'*x)
+        copy!(y, (A.X)'*x)
         return y
     end
 end
@@ -117,7 +124,7 @@ function Base.Ac_mul_B(A::FunctionMap, x::AbstractVector)
         return y
     else
         y = similar(x, promote_type(eltype(A), eltype(x)), A.N)
-        copy!(y, full(A)'*x)
+        copy!(y, (A.X)'*x)
         return y
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,9 +28,17 @@ F=LinearMap(fft, N, Complex128)/sqrt(N)
 U=full(F) # will be a unitary matrix
 @test_approx_eq U'*U eye(N)
 
+# test complement map
+N=100
+F=LinearMap(fft, ifft, N, Complex128)/sqrt(N)
+B=LinearMap(ifft, ifft, N, Complex128)/sqrt(N)
+x=rand(N)
+@test_approx_eq (F*B*N)*x x
+U=full(F) # will be a unitary matrix
+@test_approx_eq U'*U eye(N)
+
 F=LinearMap(cumsum,10)
 @test F*v==cumsum(v)
-@test_throws ErrorException F'*v
 
 # test linear combinations
 A=2*rand(Complex128,(10,10)).-1
@@ -79,7 +87,3 @@ F=SimpleFunctionMap(cumsum,10)
 w=similar(v)
 Base.A_mul_B!(w,F,v)
 @test w==F*v
-@test_throws MethodError F'*v
-@test_throws MethodError F.'*v
-@test_throws MethodError Ac_mul_B!(w,F,v)
-@test_throws MethodError At_mul_B!(w,F,v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,10 +32,10 @@ U=full(F) # will be a unitary matrix
 N=100
 F=LinearMap(fft, ifft, N, Complex128)/sqrt(N)
 B=LinearMap(ifft, ifft, N, Complex128)/sqrt(N)
-x=rand(N)
+x=rand(Complex64, N)
 @test_approx_eq (F*B*N)*x x
 U=full(F) # will be a unitary matrix
-@test_approx_eq U'*U eye(N)
+@test_approx_eq U'*U eye(Complex64, N)
 
 F=LinearMap(cumsum,10)
 @test F*v==cumsum(v)


### PR DESCRIPTION
@Jutho A complement function is not always available, so in case we want to find out the inverse mapping then that is done by multiplying the linear map's complement with the vector. ie'`full(L)'*x`