### PR TITLE
fix all depreciations of Julia-v0.6

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -4,7 +4,7 @@ export LinearMap, AbstractLinearMap
 
 import Base: +, -, *, \, /, ==
 
-abstract AbstractLinearMap{T}
+abstract type AbstractLinearMap{T} end
 Base.eltype{T}(::AbstractLinearMap{T})=T
 Base.eltype{T}(::Type{AbstractLinearMap{T}})=T
 Base.eltype{L<:AbstractLinearMap}(::Type{L})=eltype(super(L))

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -1,6 +1,6 @@
-type CompositeMap{T,As<:Tuple{Vararg{AbstractLinearMap}}} <: AbstractLinearMap{T}
+struct CompositeMap{T,As<:Tuple{Vararg{AbstractLinearMap}}} <: AbstractLinearMap{T}
     maps::As # stored in order of application to vector
-    function CompositeMap(maps::As)
+    function CompositeMap{T}(maps::As) where {T, As<:Tuple{Vararg{AbstractLinearMap}}}
         N = length(maps)
         for n = 2:N
             size(maps[n],2)==size(maps[n-1],1) || throw(DimensionMismatch("CompositeMap"))
@@ -8,10 +8,9 @@ type CompositeMap{T,As<:Tuple{Vararg{AbstractLinearMap}}} <: AbstractLinearMap{T
         for n = 1:N
             promote_type(T, eltype(maps[n])) == T || throw(InexactError())
         end
-        new(maps)
+        new{T, As}(maps)
     end
 end
-(::Type{CompositeMap{T}}){T,As<:Tuple{Vararg{AbstractLinearMap}}}(maps::As) = CompositeMap{T,As}(maps)
 
 # basic methods
 Base.size(A::CompositeMap) = (size(A.maps[end], 1), size(A.maps[1], 2))
@@ -85,11 +84,11 @@ function Base.A_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
         Base.A_mul_B!(y, A.maps[1], x)
     else
         T = eltype(y)
-        dest = Array(T, size(A.maps[1], 1))
+        dest = Array{T}(size(A.maps[1], 1))
         Base.A_mul_B!(dest, A.maps[1], x)
         source = dest
         if N>2
-            dest = Array(T,size(A.maps[2],1))
+            dest = Array{T}(size(A.maps[2],1))
         end
         for n=2:N-1
             resize!(dest, size(A.maps[n],1))
@@ -107,11 +106,11 @@ function Base.At_mul_B!(y::AbstractVector,A::CompositeMap,x::AbstractVector)
         Base.At_mul_B!(y, A.maps[1], x)
     else
         T = eltype(y)
-        dest = Array(T, size(A.maps[N], 2))
+        dest = Array{T}(size(A.maps[N], 2))
         Base.At_mul_B!(dest, A.maps[N], x)
         source = dest
         if N>2
-            dest = Array(T, size(A.maps[N-1], 2))
+            dest = Array{T}(size(A.maps[N-1], 2))
         end
         for n = N-1:-1:2
             resize!(dest, size(A.maps[n], 2))
@@ -129,11 +128,11 @@ function Base.Ac_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
         Base.Ac_mul_B!(y, A.maps[1], x)
     else
         T = eltype(y)
-        dest = Array(T, size(A.maps[N], 2))
+        dest = Array{T}(size(A.maps[N], 2))
         Base.Ac_mul_B!(dest, A.maps[N], x)
         source = dest
         if N>2
-            dest = Array(T, size(A.maps[N-1],2))
+            dest = Array{T}(size(A.maps[N-1],2))
         end
         for n = N-1:-1:2
             resize!(dest, size(A.maps[n], 2))

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -1,7 +1,7 @@
-type LinearCombination{T, As<:Tuple{Vararg{AbstractLinearMap}}, Ts<:Tuple} <: AbstractLinearMap{T}
+struct LinearCombination{T, As<:Tuple{Vararg{AbstractLinearMap}}, Ts<:Tuple} <: AbstractLinearMap{T}
     maps::As
     coeffs::Ts
-    function LinearCombination(maps::As, coeffs::Ts)
+    function LinearCombination{T}(maps::As, coeffs::Ts) where {T, As<:Tuple{Vararg{AbstractLinearMap}}, Ts<:Tuple}
         N = length(maps)
         N == length(coeffs) || error("Number of coefficients doesn't match number of terms")
         sz = size(maps[1])
@@ -9,11 +9,10 @@ type LinearCombination{T, As<:Tuple{Vararg{AbstractLinearMap}}, Ts<:Tuple} <: Ab
             size(maps[n]) == sz || throw(DimensionMismatch("LinearCombination"))
             promote_type(T, eltype(maps[n]), typeof(coeffs[n])) == T || throw(InexactError())
         end
-        new(maps, coeffs)
+        new{T,As,Ts}(maps, coeffs)
     end
 end
 
-(::Type{LinearCombination{T}}){T,As,Ts}(maps::As, coeffs::Ts) = LinearCombination{T,As,Ts}(maps, coeffs)
 
 # basic methods
 Base.size(A::LinearCombination) = size(A.maps[1])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ F=LinearMap(cumsum,2)
 N=100
 F=LinearMap(fft, N, Complex128)/sqrt(N)
 U=full(F) # will be a unitary matrix
-@test_approx_eq U'*U eye(N)
+@test U'*U ≈ eye(N)
 
 F=LinearMap(cumsum,10)
 @test F*v==cumsum(v)
@@ -43,12 +43,12 @@ v=rand(Complex128,10)
 @test full(3*M'-F)==3*A'-full(F)
 @test (3*M-1im*F)'==3*M'+1im*F'
 
-@test_approx_eq (2*M'+3*I)*v (2*A'+3*I)*v
+@test (2*M'+3*I)*v ≈ (2*A'+3*I)*v
 
 # test composition
 @test (F*F)*v==F*(F*v)
 @test (F*A)*v==F*(A*v)
-@test_approx_eq full(M*M.') A*A.'
+@test full(M*M.') ≈ A*A.'
 @test !isposdef(M*M.')
 @test isposdef(M*M')
 @test isposdef(F.'*F)
@@ -57,12 +57,12 @@ v=rand(Complex128,10)
 
 L=3*F+1im*A+F*M'*F
 LF=3*full(F)+1im*A+full(F)*full(M)'*full(F)
-@test_approx_eq full(L) LF
+@test full(L) ≈ LF
 
 # test inplace operations
 w=similar(v)
 Base.A_mul_B!(w,L,v)
-@test_approx_eq w LF*v
+@test w ≈ LF*v
 
 # test new type
 type SimpleFunctionMap <: AbstractLinearMap{Float64}


### PR DESCRIPTION
Fixing these things eliminates all warnings in Julia v0.6.

Since `CompositeMap` and `LinearCombination` use inner constructors to enforce invariants I think it's reasonable to make them immutable.
Everything else is unchanged.