### PR TITLE
Add new harmless LinearMap properties

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -16,7 +16,9 @@ Base.ishermitian{T<:Real}(A::AbstractLinearMap{T}) = issymmetric(A)
 Base.ishermitian(::AbstractLinearMap) = false # standard assumptions
 Base.isposdef(::AbstractLinearMap) = false # standard assumptions
 
+Base.ndims(::AbstractLinearMap) = 2
 Base.size(A::AbstractLinearMap, n) = (n==1 || n==2 ? size(A)[n] : error("AbstractLinearMap objects have only 2 dimensions"))
+Base.length(A::AbstractLinearMap) = reduce(*, size(A))
 
 # any AbstractLinearMap subtype will have to overwrite at least one of the two following methods to avoid running in circles
 *(A::AbstractLinearMap,x::AbstractVector)=Base.A_mul_B!(similar(x,promote_type(eltype(A),eltype(x)),size(A,1)),A,x)

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -25,8 +25,6 @@ function Base.show{T}(io::IO,A::FunctionMap{T})
 end
 
 # properties
-Base.ndims(::FunctionMap) = 2
-Base.length(A::FunctionMap) = A.M*A.N
 Base.size(A::FunctionMap) = (A.M, A.N)
 Base.issymmetric(A::FunctionMap) = A._issymmetric
 Base.ishermitian(A::FunctionMap) = A._ishermitian

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -25,6 +25,8 @@ function Base.show{T}(io::IO,A::FunctionMap{T})
 end
 
 # properties
+Base.ndims(::FunctionMap) = 2
+Base.length(A::FunctionMap) = A.M*A.N
 Base.size(A::FunctionMap) = (A.M, A.N)
 Base.issymmetric(A::FunctionMap) = A._issymmetric
 Base.ishermitian(A::FunctionMap) = A._ishermitian

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,9 @@ Base.issymmetric(A::SimpleFunctionMap)=false
 *(A::SimpleFunctionMap,v::Vector)=A.f(v)
 
 F=SimpleFunctionMap(cumsum,10)
+@test ndims(F)==2
 @test size(F,1)==10
+@test length(F)==100
 w=similar(v)
 Base.A_mul_B!(w,F,v)
 @test w==F*v


### PR DESCRIPTION
Sometimes when using matrices we do harmless tests with `ndims` and `length` in IterativeSolvers, this could help abstract LinearMaps and only discovering its type when strictly necessary.