### PR TITLE
Add fallback when `resize!` does not work

### DIFF
--- a/src/composition.jl
+++ b/src/composition.jl
@@ -93,7 +93,11 @@ function A_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             try
                 resize!(dest, size(A.maps[n], 1))
             catch err
-                dest = Array{T}(undef, size(A.maps[n], 1))
+                if err == ErrorException("cannot resize array with shared data")
+                    dest = Array{T}(undef, size(A.maps[n], 1))
+                else
+                    rethrow(err)
+                end
             end
             A_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
@@ -119,7 +123,11 @@ function At_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             try
                 resize!(dest, size(A.maps[n], 2))
             catch err
-                dest = Array{T}(undef, size(A.maps[n], 2))
+                if err == ErrorException("cannot resize array with shared data")
+                    dest = Array{T}(undef, size(A.maps[n], 2))
+                else
+                    rethrow(err)
+                end
             end
             At_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
@@ -145,7 +153,11 @@ function Ac_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             try
                 resize!(dest, size(A.maps[n], 2))
             catch err
-                dest = Array{T}(undef, size(A.maps[n], 2))
+                if err == ErrorException("cannot resize array with shared data")
+                    dest = Array{T}(undef, size(A.maps[n], 2))
+                else
+                    rethrow(err)
+                end
             end
             Ac_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -90,7 +90,11 @@ function A_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             dest = Array{T}(undef, size(A.maps[2], 1))
         end
         for n=2:N-1
-            resize!(dest, size(A.maps[n], 1))
+            try
+                resize!(dest, size(A.maps[n], 1))
+            catch err
+                dest = Array{T}(undef, size(A.maps[n], 1))
+            end
             A_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
         end
@@ -112,7 +116,11 @@ function At_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             dest = Array{T}(undef, size(A.maps[N-1], 2))
         end
         for n = N-1:-1:2
-            resize!(dest, size(A.maps[n], 2))
+            try
+                resize!(dest, size(A.maps[n], 2))
+            catch err
+                dest = Array{T}(undef, size(A.maps[n], 2))
+            end
             At_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
         end
@@ -134,7 +142,11 @@ function Ac_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
             dest = Array{T}(undef, size(A.maps[N-1], 2))
         end
         for n = N-1:-1:2
-            resize!(dest, size(A.maps[n], 2))
+            try
+                resize!(dest, size(A.maps[n], 2))
+            catch err
+                dest = Array{T}(undef, size(A.maps[n], 2))
+            end
             Ac_mul_B!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
         end

--- a/src/identitymap.jl
+++ b/src/identitymap.jl
@@ -24,7 +24,7 @@ At_mul_B!(y::AbstractVector, A::IdentityMap, x::AbstractVector) =
     (length(x) == length(y) == A.M ? copyto!(y, x) : throw(DimensionMismatch("At_mul_B!")))
 
 Ac_mul_B!(y::AbstractVector, A::IdentityMap, x::AbstractVector) =
-    (length(x) == length(y) == A.M ? copyto!(y, x) : throw(tMismatch("Ac_mul_B!")))
+    (length(x) == length(y) == A.M ? copyto!(y, x) : throw(DimensionMismatch("Ac_mul_B!")))
 
 # combine LinearMap and UniformScaling objects in linear combinations
 Base.:(+)(A1::LinearMap, A2::UniformScaling{T}) where {T} = A1 + A2[1,1] * IdentityMap{T}(size(A1, 1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,25 +29,29 @@ W = rand(ComplexF64, 20, 3)
 
 # test wrapped map for matrix
 M = LinearMap(A)
-@test M * v == A * v
-@test mul!(w, M, v) == A * v
-@test mul!(copy(W), M, V) ≈ A * V
+N = LinearMap(M)
+Av = A * v
+AV = A * V
+@test M * v == Av
+@test N * v == Av
+@test mul!(copy(w), M, v) == Av
+@test mul!(copy(w), N, v) == Av
+@test mul!(copy(W), M, V) ≈ AV
 @test typeof(M * V) <: LinearMap
-@test LinearMap(M) * v == A * v
 
 # test of mul!
 @test mul!(copy(w), M, v, 0, 0) == zero(w)
 @test mul!(copy(w), M, v, 0, 1) == w
 @test mul!(copy(w), M, v, 0, β) == β * w
-@test mul!(copy(w), M, v, 1, 1) ≈ A * v + w
-@test mul!(copy(w), M, v, 1, β) ≈ A * v + β * w
-@test mul!(copy(w), M, v, α, 1) ≈ α * A * v + w
-@test mul!(copy(w), M, v, α, β) ≈ α * A * v + β * w
-@test mul!(copy(w), M, v, α)    ≈ α * A * v
+@test mul!(copy(w), M, v, 1, 1) ≈ Av + w
+@test mul!(copy(w), M, v, 1, β) ≈ Av + β * w
+@test mul!(copy(w), M, v, α, 1) ≈ α * Av + w
+@test mul!(copy(w), M, v, α, β) ≈ α * Av + β * w
+@test mul!(copy(w), M, v, α)    ≈ α * Av
 
 # test matrix-mul!
-@test mul!(copy(W), M, V, α, β) ≈ α * A * V + β * W
-@test mul!(copy(W), M, V, α) ≈ α * A * V
+@test mul!(copy(W), M, V, α, β) ≈ α * AV + β * W
+@test mul!(copy(W), M, V, α) ≈ α * AV
 
 # test transposition and Matrix
 @test M' * w == A' * w

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,3 +179,42 @@ mul!(w, F, v)
 @test_throws MethodError transpose(F) * v
 @test_throws MethodError mul!(w, adjoint(F), v)
 @test_throws MethodError mul!(w, transpose(F), v)
+
+# test composition of several maps
+sizes = ( (5, 2), (3, 3), (3, 2), (2, 2), (9, 2), (7, 1) )
+N = length(sizes)-1
+Lf = []
+Lt = []
+Lc = []
+
+# build list of operators [LN, ..., L2, L1] for each mode
+for (fi, i) in [ (Symbol("f$i"), i) for i in 1:N]
+    @eval begin
+        function ($fi)(source)
+            dest = ones(prod(sizes[$i+1]))
+            tmp = reshape(source, sizes[$i])
+            return $i*dest
+        end
+        insert!(Lf, 1, LinearMap($fi, prod(sizes[$i+1]), prod(sizes[$i])))
+        insert!(Lt, 1, transpose(LinearMap(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1]))))
+        insert!(Lc, 1, adjoint(LinearMap{ComplexF64}(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1]))))
+    end
+end
+
+# multiply as composition and as recursion
+v1 = ones(prod(sizes[1]))
+u1 = ones(prod(sizes[1]))
+w1 = ones(ComplexF64, prod(sizes[1]))
+for i = N:-1:1
+    v2 = prod(Lf[i:N])*ones(prod(sizes[1]))
+    u2 = prod(Lt[i:N])*ones(prod(sizes[1]))
+    w2 = prod(Lc[i:N])*ones(prod(sizes[1]))
+
+    global v1 = Lf[i]*v1
+    global u1 = Lt[i]*u1
+    global w1 = Lc[i]*w1
+
+    @test v1 == v2
+    @test u1 == u2
+    @test w1 == w2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,26 +193,26 @@ for (fi, i) in [ (Symbol("f$i"), i) for i in 1:N]
         function ($fi)(source)
             dest = ones(prod(sizes[$i+1]))
             tmp = reshape(source, sizes[$i])
-            return $i*dest
+            return conj.($i*dest)
         end
         insert!(Lf, 1, LinearMap($fi, prod(sizes[$i+1]), prod(sizes[$i])))
-        insert!(Lt, 1, transpose(LinearMap(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1]))))
-        insert!(Lc, 1, adjoint(LinearMap{ComplexF64}(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1]))))
+        insert!(Lt, 1, LinearMap(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1])))
+        insert!(Lc, 1, LinearMap{ComplexF64}(x -> x, $fi, prod(sizes[$i]), prod(sizes[$i+1])))
     end
 end
 
 # multiply as composition and as recursion
 v1 = ones(prod(sizes[1]))
 u1 = ones(prod(sizes[1]))
-w1 = ones(ComplexF64, prod(sizes[1]))
+w1 = im.*ones(ComplexF64, prod(sizes[1]))
 for i = N:-1:1
     v2 = prod(Lf[i:N])*ones(prod(sizes[1]))
-    u2 = prod(Lt[i:N])*ones(prod(sizes[1]))
-    w2 = prod(Lc[i:N])*ones(prod(sizes[1]))
+    u2 = transpose(prod(Lt[N:-1:i]))*ones(prod(sizes[1]))
+    w2 = adjoint(prod(Lc[N:-1:i]))*ones(prod(sizes[1]))
 
     global v1 = Lf[i]*v1
-    global u1 = Lt[i]*u1
-    global w1 = Lc[i]*w1
+    global u1 = transpose(Lt[i])*u1
+    global w1 = adjoint(Lc[i])*w1
 
     @test v1 == v2
     @test u1 == u2


### PR DESCRIPTION
I have been thinking about the issue #24 (using `resize!` within the composition operator) and have come to the conclusion that users should not be expected to always provide "clean" arrays which can be resized. Take my case for example, I had to essentially change my function by adding a couple of `copy` commands to ensure `resize!` was working. I was only able to do this after guidance. In fact, I have a more complex example (which I won't share because it is pretty long and specific) that I simply cannot get to work with the current code. Copying data both at the input and at the output do not work. I have [another (somewhat contrived) example](https://gist.github.com/cako/6b45d34eda9b4498ed8014a7659eaedb) demonstrates how this can happen. It can also be used for code coverage if the commit is accepted.

So either we can accept that some people's code will mess with the array in such a way that it cannot be resized, or we make them accept the fact that the library is not for them. I don't think the latter is beneficial for anyone!

On the other hand, I fully appreciate that `resize!` is much faster than array creation. I [benchmarked](https://gist.github.com/cako/2c42402d96cedbcf9b848704d79adc3a) resizing an array of size `1000` to several different sizes, ranging from `100` to `100_000`. The cost of only the resizing is in orange, while the cost of allocating from scratch is shown in green.
![benchmark](https://user-images.githubusercontent.com/645570/47333964-bfe24080-d64a-11e8-8ea7-184cca5f6066.png)

Clearly allocating from scratch grows linearly, while resizing may eventually be linear as well, but it is offset by how much has already been allocated.

So I propose a very simple solution that I think will make everyone happy: we resize when we can, and when we can't, we allocate. I have added a simple try/catch block to do this. As shown in the figure above, this "fix" (blue line) retains decent performance for larger arrays, and is still much better than allocating for smaller arrays. It also has the obvious benefit of not breaking anyone's code!

The commits are very simple, simply wrap all `resize!` calls with a try/catch block which in the catch statement allocates an array.

