### PR TITLE
fixing the quaternion and octonion tests by adding definition of norm…

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -7,6 +7,23 @@ using SparseArrays
 
 abstract type LinearMap{T} end
 
+using Quaternions
+import LinearAlgebra: norm
+function norm(x::Union{Array{Octonion{T},1},Array{Quaternion{T},1}}) where T
+    index = 1 
+    a = zeros(length(x))
+    for i ∈ x 
+        a[index]=abs(i)
+        index += 1
+    end 
+    return norm(a)
+end
+
+function norm(x::Union{Array{Octonion{T},2},Array{Quaternion{T},2}}) where T
+    a = vec(x)
+    return norm(a)
+end
+
 Base.eltype(::LinearMap{T}) where {T} = T
 
 Base.isreal(A::LinearMap) = eltype(A) <: Real


### PR DESCRIPTION
… of quaternion and octonion vertors and matrices.

As I have mentioned in the issue part, the main problem of these quaternion and octonion tests don't work is the lack of definition of norms, since a call of approximate sign will call norm of difference automatically.
To fix this problem, I defined norms for quaternions and octonions, which follows the mathematica way.(since I dont think there is any strict definition in abstract math) The norm for vectors are just the square root of the sum of all squares, and the norm for matrices follows the frabenius norm. This slight change fix the problem.
Although the problem is fixed for now, I still insist that the different definition of conjugate of quaternions will result in problems in At_mult_B, hope that you could check soon.