### PR TITLE
disallow test failures on Julia v1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ julia:
 
 matrix:
   allow_failures:
-    - julia: 1.2
     - julia: nightly
 notifications:
     email: false


### PR DESCRIPTION
The missing `float` method for `Octonion` has been merged and tagged in `Quaternions.jl`, so there is no reason to allow test failure on Julia v1.2.