### PR TITLE
Add block maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ notifications:
 
 
 after_success:
-  - julia -e 'cd(Pkg.dir("LinearMaps")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder()); Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder()); Coveralls.submit(Coveralls.process_folder())'

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -111,6 +111,7 @@ include("composition.jl") # composition of linear maps
 include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
 include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I
 include("functionmap.jl") # using a function as linear map
+include("blockmap.jl") # block linear maps
 
 """
     LinearMap(A; kwargs...)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -1,222 +1,58 @@
 ##############
-# BlockSizes #
-##############
-
-abstract type AbstractBlockSizes end
-
-# Keeps track of the (cumulative) sizes of all the blocks in the `BlockMap`.
-struct BlockSizes{VT<:Tuple{Vector{Int},Vector{Int}}} <: AbstractBlockSizes
-    cumul_sizes::VT
-    # Takes a tuple of sizes, accumulates them and create a `BlockSizes`
-    BlockSizes{VT}() where {VT<:Tuple{Vector{Int},Vector{Int}}} = new{VT}()
-    BlockSizes{VT}(cs::VT) where {VT<:Tuple{Vector{Int},Vector{Int}}} = new{VT}(cs)
-end
-
-BlockSizes(cs::VT) where {VT<:Tuple{Vector{Int},Vector{Int}}} = BlockSizes{typeof(cs)}(cs)
-# BlockSizes(cs::Tuple{Vector{Int},Vector{Int}}) = BlockSizes(cs)
-
-function BlockSizes(size1::AbstractVector{Int}, size2::AbstractVector{Int})
-    cumul_sizes = (_cumul_vec(size1), _cumul_vec(size2))
-    return BlockSizes(cumul_sizes)
-end
-
-Base.:(==)(a::BlockSizes, b::BlockSizes) = cumulsizes(a) == cumulsizes(b)
-
-Base.dataids(b::BlockSizes) = _splatmap(dataids, b.cumul_sizes)
-# _splatmap taken from Base:
-_splatmap(f, ::Tuple{}) = ()
-_splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
-
-function _cumul_vec(v::AbstractVector{T}) where {T}
-    v_cumul = similar(v, length(v) + 1)
-    z = one(T)
-    v_cumul[1] = z
-    for i in eachindex(v)
-        z += v[i]
-        v_cumul[i+1] = z
-    end
-    return v_cumul
-end
-
-Base.@propagate_inbounds cumulsizes(block_sizes::BlockSizes) = block_sizes.cumul_sizes
-Base.@propagate_inbounds cumulsizes(block_sizes::AbstractBlockSizes, i) = cumulsizes(block_sizes)[i]
-Base.@propagate_inbounds cumulsizes(block_sizes::AbstractBlockSizes, i, j) = cumulsizes(block_sizes,i)[j]
-
-Base.@propagate_inbounds blocksize(block_sizes::AbstractBlockSizes, i, j) =
-    cumulsizes(block_sizes, i, j+1) - cumulsizes(block_sizes, i, j)
-
-function blocksize(block_sizes::AbstractBlockSizes, i::Tuple{Integer, Integer})
-    return blocksize(block_sizes, 1, i[1]), blocksize(block_sizes, 1, i[1])
-end
-
-# Gives the total sizes
-function Base.size(block_sizes::AbstractBlockSizes)
-    @inbounds return cumulsizes(block_sizes, 1)[end] - 1, cumulsizes(block_sizes, 2)[end] - 1
-end
-
-function Base.show(io::IO, block_sizes::AbstractBlockSizes)
-    print(io, " × ", diff(cumulsizes(block_sizes, 2)))
-end
-
-@inline function searchlinear(vec::AbstractVector, a)
-    l = length(vec)
-    @inbounds for i in 1:l
-        vec[i] > a && return i - 1
-    end
-    return l
-end
-
-_find_block(bs::AbstractVector, i::Integer) = length(bs) > 10 ? last(searchsorted(bs, i)) : searchlinear(bs, i)
-
-@inline function _find_block(block_sizes::AbstractBlockSizes, dim::Integer, i::Integer)
-    bs = cumulsizes(block_sizes, dim)
-    block = _find_block(bs, i)
-    @inbounds cum_size = cumulsizes(block_sizes, dim, block) - 1
-    return block, i - cum_size
-end
-
-nblocks(block_sizes::AbstractBlockSizes) = nblocks(block_sizes, 1), nblocks(block_sizes, 2)
-
-# @inline nblocks(block_array::AbstractArray) = nblocks(blocksizes(block_array))
-
-@inline Base.@propagate_inbounds nblocks(block_sizes::AbstractBlockSizes, i::Integer) =
-    length(cumulsizes(block_sizes, i)) - 1
-
-function nblocks(block_sizes::AbstractBlockSizes, i::Integer, j::Integer)
-    b = nblocks(block_sizes)
-    return b[i], b[j]
-end
-
-function Base.copy(block_sizes::BlockSizes)
-    return BlockSizes(copy(cumulsizes(block_sizes, 1)), copy(cumulsizes(block_sizes, 2)))
-end
-
-@inline function globalrange(block_sizes::AbstractBlockSizes, block_index::NTuple{2, Integer})
-    @inbounds v = (cumulsizes(block_sizes, 1, block_index[1]):cumulsizes(block_sizes, 1, block_index[1] + 1) - 1,
-                   cumulsizes(block_sizes, 2, block_index[2]):cumulsizes(block_sizes, 2, block_index[2] + 1) - 1)
-    return v
-end
-
-"""
-    blocksize(A, inds)
-
-Returns a tuple containing the size of the block at block index `inds`.
-"""
-
-@inline blocksize(block_array::AbstractArray, i::Integer...) =
-    blocksize(blocksizes(block_array), i...)
-
-@inline blocksize(block_array::AbstractMatrix{T}, i::Tuple{Integer, Integer}) where {T} =
-    blocksize(blocksizes(block_array), i)
-
-cumulsizes(A::AbstractArray) = cumulsizes(blocksizes(A))
-@inline cumulsizes(A::AbstractArray, i) = cumulsizes(blocksizes(A), i)
-@inline cumulsizes(A::AbstractArray, i, j) = cumulsizes(blocksizes(A), i, j)
-
-##############
 # BlockMaps #
 ##############
 
-abstract type AbstractBlockMap{T,As,Bs} <: LinearMap{T} end
+abstract type AbstractBlockMap{T,As} <: LinearMap{T} end
 
-struct HBlockMap{T,As<:Tuple{Vararg{LinearMap}},BS<:AbstractBlockSizes} <: AbstractBlockMap{T,As,BS}
+struct HBlockMap{T,As<:Tuple{Vararg{LinearMap}}} <: AbstractBlockMap{T,As}
     maps::As
-    block_sizes::BS
-    global function _HBlockMap(maps::R, block_sizes::BS) where {T, R<:Tuple{Vararg{LinearMap{T}}}, BS<:AbstractBlockSizes}
-        new{T, R, BS}(maps, block_sizes)
+    block_sizes::Tuple{Vector{Int},Vector{Int}}
+    function HBlockMap(maps::R, block_sizes::Tuple{Vector{Int},Vector{Int}}) where {T, R<:Tuple{Vararg{LinearMap{T}}}}
+        new{T,R}(maps, block_sizes)
     end
 end
 
-struct VBlockMap{T,As<:Tuple{Vararg{LinearMap}},BS<:AbstractBlockSizes} <: AbstractBlockMap{T,As,BS}
+struct VBlockMap{T,As<:Tuple{Vararg{LinearMap}}} <: AbstractBlockMap{T,As}
     maps::As
-    block_sizes::BS
-    global function _VBlockMap(maps::R, block_sizes::BS) where {T, R<:Tuple{Vararg{LinearMap{T}}}, BS<:AbstractBlockSizes}
-        new{T, R, BS}(maps, block_sizes)
+    block_sizes::Tuple{Vector{Int},Vector{Int}}
+    function VBlockMap(maps::R, block_sizes::Tuple{Vector{Int},Vector{Int}}) where {T, R<:Tuple{Vararg{LinearMap{T}}}}
+        new{T,R}(maps, block_sizes)
     end
 end
 
-# BlockMap(maps::Tuple{Vararg{LinearMap}}, rows::Integer) = isone(rows) ? _HBlockMap(maps, sizes_from_maps(maps, rows))
-HBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = _HBlockMap(maps, sizes_from_maps(maps, 1))
-VBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = _VBlockMap(maps, sizes_from_maps(maps, length(maps)))
+HBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = HBlockMap(maps, sizes_from_maps_h(maps))
+VBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = VBlockMap(maps, sizes_from_maps_v(maps))
 
-function sizes_from_maps(maps::Tuple{Vararg{LinearMap}}, rows::Integer)
-	N = length(maps)
-	if N == 0
-        return zeros.(Int, size(maps))
-    end
-	cols, rem = divrem(N, rows)
-    if rem != 0
-        error("Cannot construct a BlockMap with $rows block rows from $N linear maps")
-    end
-    fullsizes::Array{Tuple{Int,Int}} = reshape([map(size, maps)...,], rows, cols)
-    block_sizes = ntuple(2) do i
-        [s[i] for s in view(fullsizes, ntuple(j -> j == i ? (:) : 1, 2)...)]
-    end
-    checksizes(fullsizes, block_sizes)
-    return BlockSizes(block_sizes...)
-end
-
-getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)
-
-function checksizes(fullsizes::Matrix{Tuple{Int,Int}}, block_sizes::Tuple{Vector{Int},Vector{Int}})
-    Base.@nloops 2 i fullsizes begin
-        block_index = Base.@ntuple 2 i
-        if fullsizes[block_index...] != getsizes(block_sizes, block_index)
-			error("size(blocks[", strip(repr(block_index), ['(', ')']),
-                      "]) (= ", fullsizes[block_index...],
-                      ") is incompatible with expected size: ",
-                      getsizes(block_sizes, block_index))
-        end
-    end
-    return fullsizes
-end
-
-@inline Base.size(A::AbstractBlockMap) = size(blocksizes(A))
-
-"""
-    blocksizes(A)
-
-Returns a subtype of `AbstractBlockSizes` that contains information about the
-block sizes of `A`.
-"""
-@inline blocksizes(A::AbstractBlockMap) = A.block_sizes
-
-@inline function blockcheckbounds(A::AbstractBlockMap{T}, i::Integer, j::Integer) where {T}
-    n = nblocks(A)
-	if i <= 0 || i > n[1]
-		return throw(BoundsError(A, (i, j)))
+function sizes_from_maps_h(maps::Tuple{Vararg{LinearMap}})::Tuple{Vector{Int},Vector{Int}} where {T}
+	m = size(maps[1], 1)
+	for map in maps
+		m == size(map, 1) || throw(DimensionMismatch())
 	end
-	if j <= 0 || j > n[2]
-		return throw(BoundsError(A, (i, j)))
+	return [1, m+1], cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 2), maps)...,])
+end
+function sizes_from_maps_v(maps::Tuple{Vararg{LinearMap}})::Tuple{Vector{Int},Vector{Int}} where {T}
+	n = size(maps[1], 2)
+	for map in maps
+		n == size(map, 2) || throw(DimensionMismatch())
 	end
-    return nothing
+	return cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 1), maps)...,]), [1, n+1]
 end
 
-@inline nblocks(A::AbstractBlockMap) = nblocks(blocksizes(A))
-
-nblocks(A::AbstractBlockMap, i::Integer) = nblocks(A)[i]
-
-nblocks(A::AbstractBlockMap, i::Integer, j::Integer) = nblocks(blocksizes(A), i, j)
-
-@inline function getblock(A::AbstractBlockMap, i::Integer, j::Integer)
-    @boundscheck blockcheckbounds(A, i, j)
-	m, n = nblocks(A)
-    A.maps[(j-1)*m + i]
-end
+@inline Base.size(A::AbstractBlockMap) = (A.block_sizes[1][end]-1, A.block_sizes[2][end]-1)
 
 ############
 # hcat
 ############
 
 function Base.hcat(As::Union{LinearMap,UniformScaling}...)
-    nrows = 0
 	T = promote_type(map(eltype, As)...)
 	for A in As
 		if !(A isa UniformScaling)
-			eltype(A) == T || throw(ArgumentError("eltype type mismatch in hcat of linear maps"))
+			eltype(A) == T || throw(ArgumentError("eltype mismatch in hcat of linear maps"))
 		end
 	end
 
+	nrows = 0
 	# find first non-UniformScaling to detect number of rows
 	for A in As
 		if !(A isa UniformScaling)
@@ -230,26 +66,18 @@ function Base.hcat(As::Union{LinearMap,UniformScaling}...)
 		if A isa UniformScaling
 			return UniformScalingMap(convert(T, A.λ), nrows)
 		else
-			size(A, 1) == nrows || throw(DimensionMismatch("hcat of LinearMaps"))
+			# size(A, 1) == nrows || throw(DimensionMismatch("hcat of LinearMaps"))
 			return A
 		end
 	end
 	return hcat(maps...)
 end
-function Base.hcat(A::LinearMap{T}, As::LinearMap{T}...) where {T}
-	for Ai in As
-		size(A, 1) == size(Ai, 1) || throw(DimensionMismatch("hcat of LinearMaps"))
-	end
-	hcat(A, hcat(As...))
-end
-function Base.hcat(A::LinearMap{T}, B::LinearMap{T}) where {T}
-	size(A, 1) == size(B, 1) || throw(DimensionMismatch("hcat of LinearMaps"))
-	HBlockMap(tuple(A, B))
-end
+Base.hcat(A::LinearMap{T}, As::LinearMap{T}...) where {T} = hcat(A, hcat(As...))
+Base.hcat(A::LinearMap{T}, B::LinearMap{T}) where {T} = HBlockMap(tuple(A, B))
 Base.hcat(A::LinearMap{T}, B::HBlockMap{T}) where {T} = HBlockMap(tuple(A, B.maps...))
+Base.hcat(A::HBlockMap{T}, B::HBlockMap{T}) where {T} = HBlockMap(tuple(A.maps..., B.maps...))
 
 function Base.vcat(As::Union{LinearMap,UniformScaling}...)
-    ncols = 0
 	T = promote_type(map(eltype, As)...)
 	for A in As
 		if !(A isa UniformScaling)
@@ -257,6 +85,7 @@ function Base.vcat(As::Union{LinearMap,UniformScaling}...)
 		end
 	end
 
+	ncols = 0
 	# find first non-UniformScaling to detect number of columns
 	for A in As
 		if !(A isa UniformScaling)
@@ -270,23 +99,16 @@ function Base.vcat(As::Union{LinearMap,UniformScaling}...)
 		if A isa UniformScaling
 			return UniformScalingMap(convert(T, A.λ), ncols)
 		else
-			size(A, 2) == ncols || throw(DimensionMismatch("vcat of LinearMaps"))
+			# size(A, 2) == ncols || throw(DimensionMismatch("vcat of LinearMaps"))
 			return A
 		end
 	end
 	return vcat(maps...)
 end
-function Base.vcat(A::LinearMap{T}, As::LinearMap{T}...) where {T}
-	for Ai in As
-		size(A, 2) == size(Ai, 2) || throw(DimensionMismatch("vcat of LinearMaps"))
-	end
-	return vcat(A, vcat(As...))
-end
-function Base.vcat(A::LinearMap{T}, B::LinearMap{T}) where {T}
-	size(A, 2) == size(B, 2) || throw(DimensionMismatch("vcat of LinearMaps"))
-	return VBlockMap(tuple(A, B))
-end
+Base.vcat(A::LinearMap{T}, As::LinearMap{T}...) where {T} = vcat(A, vcat(As...))
+Base.vcat(A::LinearMap{T}, B::LinearMap{T}) where {T} = VBlockMap(tuple(A, B))
 Base.vcat(A::LinearMap{T}, B::VBlockMap{T}) where {T} = VBlockMap(tuple(A, B.maps...))
+Base.vcat(A::VBlockMap{T}, B::VBlockMap{T}) where {T} = VBlockMap(tuple(A.maps..., B.maps...))
 
 function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling}...)
 	T = promote_type(map(eltype, As)...)
@@ -344,24 +166,22 @@ function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling
 		if As[i] isa UniformScaling
 			return UniformScalingMap(convert(T, As[i].λ), n[i])
 		else
-			# size(A, 2) == n[i] || throw(DimensionMismatch("vcat of LinearMaps"))
 			return As[i] # size check is going to be performed in h/v/cat below
 		end
 	end
 
 	return hvcat(rows, maps)
 end
-
 function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Tuple{Vararg{LinearMap{T}}}) where {T}
 	nr = length(rows)
 	j = 0
 	A::NTuple{nr,HBlockMap{T}} = ntuple(nr) do i
 		hmaps = As[j+1:j+rows[i]]
 		j += rows[i]
-		return hcat(hmaps...)::HBlockMap{T,typeof(hmaps)}
+		return hcat(hmaps...)
     end
 
-    return vcat(A...)::VBlockMap{T,typeof(A)}
+    return vcat(A...)
 end
 
 ############
@@ -414,48 +234,32 @@ LinearAlgebra.adjoint(A::HBlockMap)   = VBlockMap(map(adjoint, A.maps))
 # multiplication with vectors
 ############
 
-function A_mul_B!(y::AbstractVector, A::AbstractBlockMap, x::AbstractVector)
+function A_mul_B!(y::AbstractVector, A::HBlockMap, x::AbstractVector)
     M, N = size(A)
     (length(x) == N && length(y) == M) || throw(DimensionMismatch())
-    yinds, xinds = cumulsizes(A.block_sizes)
-    # fill y with results of first block column
-    @inbounds for i in 1:nblocks(A, 1)
-        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], getblock(A, i, 1), x[xinds[1]:xinds[2]-1])
-    end
-    # add to y results of the following block columns
-    @inbounds for j in 2:nblocks(A, 2), i in 1:nblocks(A, 1)
-        @views mul!(y[yinds[i]:yinds[i+1]-1], getblock(A, i, j), x[xinds[j]:xinds[j+1]-1], 1, 1)
+    _, xinds = A.block_sizes
+    # fill y with results of first block
+	A_mul_B!(y, A.maps[1], @views x[xinds[1]:xinds[2]-1])
+	# add to y results of the following block columns
+    @inbounds @views for j in 2:length(A.maps)
+        mul!(y, A.maps[j], x[xinds[j]:xinds[j+1]-1], 1, 1)
     end
     return y
 end
-function At_mul_B!(y::AbstractVector, A::AbstractBlockMap, x::AbstractVector)
-    M, N = size(A)
-    (length(x) == N && length(y) == M) || throw(DimensionMismatch())
-    xinds, yinds = cumulsizes(A.block_sizes)
-    # fill y with results of first block column
-    @inbounds for i in 1:nblocks(A, 2)
-        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], transpose(getblock(A, 1, i)), x[xinds[1]:xinds[2]-1])
-    end
-    # add to y results of the following block columns
-    @inbounds for j in 2:nblocks(A, 1), i in 1:nblocks(A, 2)
-        @views mul!(y[yinds[i]:yinds[i+1]-1], transpose(getblock(A, j, i)), x[xinds[j]:xinds[j+1]-1], 1, 1)
-    end
-    return y
-end
-function Ac_mul_B!(y::AbstractVector, A::AbstractBlockMap, x::AbstractVector)
+function A_mul_B!(y::AbstractVector, A::VBlockMap, x::AbstractVector)
 	M, N = size(A)
     (length(x) == N && length(y) == M) || throw(DimensionMismatch())
-    xinds, yinds = cumulsizes(A.block_sizes)
-    # fill y with results of first block column
-    @inbounds for i in 1:nblocks(A, 2)
-        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], adjoint(getblock(A, 1, i)), x[xinds[1]:xinds[2]-1])
-    end
-    # add to y results of the following block columns
-    @inbounds for j in 2:nblocks(A, 1), i in 1:nblocks(A, 2)
-        @views mul!(y[yinds[i]:yinds[i+1]-1], adjoint(getblock(A, j, i)), x[xinds[j]:xinds[j+1]-1], 1, 1)
+    yinds, _ = A.block_sizes
+    # fill parts of y according to block sizes
+	@inbounds @views for j in 1:length(A.maps)
+        A_mul_B!(y[yinds[j]:yinds[j+1]-1], A.maps[j], x)
     end
     return y
 end
+
+At_mul_B!(y::AbstractVector, A::AbstractBlockMap, x::AbstractVector) = A_mul_B!(y, transpose(A), x)
+
+Ac_mul_B!(y::AbstractVector, A::AbstractBlockMap, x::AbstractVector) = A_mul_B!(y, adjoint(A), x)
 
 ############
 # show methods

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -1,0 +1,457 @@
+##############
+# BlockSizes #
+##############
+
+abstract type AbstractBlockSizes end
+
+# Keeps track of the (cumulative) sizes of all the blocks in the `BlockMap`.
+struct BlockSizes{VT<:Tuple{Vector{Int},Vector{Int}}} <: AbstractBlockSizes
+    cumul_sizes::VT
+    # Takes a tuple of sizes, accumulates them and create a `BlockSizes`
+    BlockSizes{VT}() where {VT<:Tuple{Vector{Int},Vector{Int}}} = new{VT}()
+    BlockSizes{VT}(cs::VT) where {VT<:Tuple{Vector{Int},Vector{Int}}} = new{VT}(cs)
+end
+
+BlockSizes(cs::VT) where {VT<:Tuple{Vector{Int},Vector{Int}}} = BlockSizes{typeof(cs)}(cs)
+# BlockSizes(cs::Tuple{Vector{Int},Vector{Int}}) = BlockSizes(cs)
+
+function BlockSizes(size1::AbstractVector{Int}, size2::AbstractVector{Int})
+    cumul_sizes = (_cumul_vec(size1), _cumul_vec(size2))
+    return BlockSizes(cumul_sizes)
+end
+
+Base.:(==)(a::BlockSizes, b::BlockSizes) = cumulsizes(a) == cumulsizes(b)
+
+Base.dataids(b::BlockSizes) = _splatmap(dataids, b.cumul_sizes)
+# _splatmap taken from Base:
+_splatmap(f, ::Tuple{}) = ()
+_splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
+
+function _cumul_vec(v::AbstractVector{T}) where {T}
+    v_cumul = similar(v, length(v) + 1)
+    z = one(T)
+    v_cumul[1] = z
+    for i in eachindex(v)
+        z += v[i]
+        v_cumul[i+1] = z
+    end
+    return v_cumul
+end
+
+Base.@propagate_inbounds cumulsizes(block_sizes::BlockSizes) = block_sizes.cumul_sizes
+Base.@propagate_inbounds cumulsizes(block_sizes::AbstractBlockSizes, i) = cumulsizes(block_sizes)[i]
+Base.@propagate_inbounds cumulsizes(block_sizes::AbstractBlockSizes, i, j) = cumulsizes(block_sizes,i)[j]
+
+Base.@propagate_inbounds blocksize(block_sizes::AbstractBlockSizes, i, j) =
+    cumulsizes(block_sizes, i, j+1) - cumulsizes(block_sizes, i, j)
+
+function blocksize(block_sizes::AbstractBlockSizes, i::Tuple{Integer, Integer})
+    return blocksize(block_sizes, 1, i[1]), blocksize(block_sizes, 1, i[1])
+end
+
+# Gives the total sizes
+function Base.size(block_sizes::AbstractBlockSizes)
+    @inbounds return cumulsizes(block_sizes, 1)[end] - 1, cumulsizes(block_sizes, 2)[end] - 1
+end
+
+function Base.show(io::IO, block_sizes::AbstractBlockSizes)
+    print(io, " × ", diff(cumulsizes(block_sizes, 2)))
+end
+
+@inline function searchlinear(vec::AbstractVector, a)
+    l = length(vec)
+    @inbounds for i in 1:l
+        vec[i] > a && return i - 1
+    end
+    return l
+end
+
+_find_block(bs::AbstractVector, i::Integer) = length(bs) > 10 ? last(searchsorted(bs, i)) : searchlinear(bs, i)
+
+@inline function _find_block(block_sizes::AbstractBlockSizes, dim::Integer, i::Integer)
+    bs = cumulsizes(block_sizes, dim)
+    block = _find_block(bs, i)
+    @inbounds cum_size = cumulsizes(block_sizes, dim, block) - 1
+    return block, i - cum_size
+end
+
+nblocks(block_sizes::AbstractBlockSizes) = nblocks(block_sizes, 1), nblocks(block_sizes, 2)
+
+# @inline nblocks(block_array::AbstractArray) = nblocks(blocksizes(block_array))
+
+@inline Base.@propagate_inbounds nblocks(block_sizes::AbstractBlockSizes, i::Integer) =
+    length(cumulsizes(block_sizes, i)) - 1
+
+function nblocks(block_sizes::AbstractBlockSizes, i::Integer, j::Integer)
+    b = nblocks(block_sizes)
+    return b[i], b[j]
+end
+
+function Base.copy(block_sizes::BlockSizes)
+    return BlockSizes(copy(cumulsizes(block_sizes, 1)), copy(cumulsizes(block_sizes, 2)))
+end
+
+@inline function globalrange(block_sizes::AbstractBlockSizes, block_index::NTuple{2, Integer})
+    @inbounds v = (cumulsizes(block_sizes, 1, block_index[1]):cumulsizes(block_sizes, 1, block_index[1] + 1) - 1,
+                   cumulsizes(block_sizes, 2, block_index[2]):cumulsizes(block_sizes, 2, block_index[2] + 1) - 1)
+    return v
+end
+
+"""
+    blocksize(A, inds)
+
+Returns a tuple containing the size of the block at block index `inds`.
+"""
+
+@inline blocksize(block_array::AbstractArray, i::Integer...) =
+    blocksize(blocksizes(block_array), i...)
+
+@inline blocksize(block_array::AbstractMatrix{T}, i::Tuple{Integer, Integer}) where {T} =
+    blocksize(blocksizes(block_array), i)
+
+cumulsizes(A::AbstractArray) = cumulsizes(blocksizes(A))
+@inline cumulsizes(A::AbstractArray, i) = cumulsizes(blocksizes(A), i)
+@inline cumulsizes(A::AbstractArray, i, j) = cumulsizes(blocksizes(A), i, j)
+
+##############
+# BlockMaps #
+##############
+
+struct BlockMap{T, R <: AbstractMatrix{<:LinearMap{T}}, BS<:AbstractBlockSizes} <: LinearMap{T}
+    maps::R
+    block_sizes::BS
+
+    global function _BlockMap(blocks::R, block_sizes::BS) where {T, R<:AbstractMatrix{<:LinearMap{T}}, BS<:AbstractBlockSizes}
+        new{T, R, BS}(blocks, block_sizes)
+    end
+end
+
+function _BlockMap(maps::R, b_sizes1::AbstractVector{Int}, b_sizes2::AbstractVector{Int}) where {T, R<:AbstractMatrix{<:LinearMap{T}}}
+    return _BlockMap(maps, BlockSizes(b_sizes1, b_sizes2))
+end
+
+function BlockMap(maps::AbstractMatrix{T}, b_sizes1::AbstractVector{Int}, b_sizes2::AbstractVector{Int}) where {T}
+    if sum(b_sizes1) != size(maps, 1)
+        throw(DimensionMismatch("block size for dimension 1: $b_sizes1 does not sum to the array size: $(size(maps, 1))"))
+    elseif sum(b_sizes2) != size(maps, 2)
+        throw(DimensionMismatch("block size for dimension 2: $b_sizes2 does not sum to the array size: $(size(maps, 2))"))
+    end
+    return _BlockMap(maps, BlockSizes(b_sizes1, b_sizes2))
+end
+
+BlockMap(maps::AbstractArray{<:LinearMap}) = _BlockMap(maps, sizes_from_maps(maps))
+BlockMap(maps::AbstractVector{<:LinearMap}) = BlockMap(reshape(maps, (length(maps), 1)))
+
+function sizes_from_maps(maps::AbstractMatrix{<:Any})
+    if length(maps) == 0
+        return zeros.(Int, size(maps))
+    end
+    if !all(b -> ndims(b) == 2, maps)
+        error("All blocks must have ndims = 2.")
+    end
+    fullsizes = map!(size, Matrix{Tuple{Int,Int}}(undef, size(maps)), maps)
+    block_sizes = ntuple(ndims(maps)) do i
+        [s[i] for s in view(fullsizes, ntuple(j -> j == i ? (:) : 1, ndims(maps))...)]
+    end
+    checksizes(fullsizes, block_sizes)
+    return BlockSizes(block_sizes...)
+end
+
+getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)
+
+function checksizes(fullsizes::Array{Tuple{Int,Int},2}, block_sizes::Tuple{Vector{Int},Vector{Int}})
+    Base.@nloops 2 i fullsizes begin
+        block_index = Base.@ntuple 2 i
+        if fullsizes[block_index...] != getsizes(block_sizes, block_index)
+            error("size(blocks[", strip(repr(block_index), ['(', ')']),
+                  "]) (= ", fullsizes[block_index...],
+                  ") is incompatible with expected size: ",
+                  getsizes(block_sizes, block_index))
+        end
+    end
+    return fullsizes
+end
+
+@inline Base.size(bmap::BlockMap) = size(blocksizes(bmap))
+
+"""
+    blocksizes(A)
+
+Returns a subtype of `AbstractBlockSizes` that contains information about the
+block sizes of `A`.
+"""
+@inline blocksizes(bmap::BlockMap) = bmap.block_sizes
+
+@inline function blockcheckbounds(A::BlockMap{T}, i::Integer, j::Integer) where {T}
+    n = nblocks(A)
+	if i <= 0 || i > n[1]
+		return throw(BoundsError(A, (i, j)))
+	end
+	if j <= 0 || j > n[2]
+		return throw(BoundsError(A, (i, j)))
+	end
+    return nothing
+end
+
+@inline nblocks(bmap::BlockMap) = nblocks(blocksizes(bmap))
+
+nblocks(bmap::BlockMap, i::Integer) = nblocks(bmap)[i]
+
+nblocks(bmap::BlockMap, i::Integer, j::Integer) = nblocks(blocksizes(bmap), i, j)
+
+@inline function getblock(bmap::BlockMap, i::Integer, j::Integer)
+    @boundscheck blockcheckbounds(bmap, i, j)
+    bmap.maps[i, j]
+end
+
+############
+# hcat
+############
+
+function Base.hcat(As::Union{LinearMap,UniformScaling}...)
+    T = Base.promote_op(*, map(eltype, As)...)
+    nrows = 0
+	for A in As
+		if A != I
+			nrows = size(A, 1)
+			break
+		end
+	end
+	nrows == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
+	X = map(As) do A
+		if A isa UniformScaling
+			return LinearMap{T}(UniformScalingMap(convert(T, A.λ), nrows))
+		else
+			return LinearMap{T}(A) # eltype(A) == T ? A : LinearMap{T}(A)
+		end
+	end
+	return BlockMap(Base.typed_hcat(WrappedMap{T}, X...))
+end
+
+function Base.hcat(As::BlockMap...)
+    cs = cumulsizes(As[1].block_sizes[1])
+    T = promote_type(map(eltype, As)...)
+    for A in As
+        cs == cumulsizes(A.block_sizes[1]) || throw(DimensionMismatch("hcat of BlockMaps"))
+    end
+    return BlockMap(hcat(map(A -> LinearMap{T}.(getfield(A, :maps)), As)...))
+end
+function Base.hcat(As::BlockMap{T}...) where {T}
+    cs = cumulsizes(As[1].block_sizes)[1]
+    for A in As
+        cs == cumulsizes(A.block_sizes)[1] || throw(DimensionMismatch("hcat of BlockMaps"))
+    end
+    return BlockMap(hcat(map(A -> getfield(A, :maps), As)...))
+end
+
+############
+# vcat
+############
+
+function Base.vcat(As::Union{LinearMap,UniformScaling}...)
+	T = Base.promote_op(*, map(eltype, As)...)
+    ncols = 0
+	for A in As
+		if A != I
+			ncols = size(A, 1)
+			break
+		end
+	end
+	ncols == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
+	X = map(As) do A
+		if A isa UniformScaling
+			return LinearMap{T}(UniformScalingMap(convert(T, A.λ), ncols))
+		else
+			return LinearMap{T}(A) # eltype(A) == T ? A : LinearMap{T}(A)
+		end
+	end
+	return BlockMap(Base.typed_vcat(WrappedMap{T}, X...))
+end
+
+function Base.vcat(As::BlockMap...)
+    cs = cumulsizes(As[1].block_sizes[2])
+    T = promote_type((A -> eltype(A) for A in As)...)
+    for A in As
+        cs == cumulsizes(A.block_sizes[2]) || throw(DimensionMismatch("hcat of BlockMaps"))
+    end
+    return BlockMap(vcat(map(A -> LinearMap{T}.(getfield(A, :maps)), As)...))
+end
+function Base.vcat(As::BlockMap{T}...) where {T}
+    cs = cumulsizes(As[1].block_sizes)[2]
+    for A in As
+        cs == cumulsizes(A.block_sizes)[2] || throw(DimensionMismatch("hcat of BlockMaps"))
+    end
+    return BlockMap(vcat(map(A -> getfield(A, :maps), As)...))
+end
+
+function Base.hvcat(rows::Tuple{Vararg{Int}}, A::Union{LinearMap,UniformScaling}...)
+	T = Base.promote_op(*, map(eltype, A)...)
+    nr = length(rows)
+    sum(rows) == length(A) || throw(ArgumentError("mismatch between row sizes and number of arguments"))
+    n = fill(-1, length(A))
+    needcols = false # whether we also need to infer some sizes from the column count
+    j = 0
+    for i = 1:nr # infer UniformScaling sizes from row counts, if possible:
+        ni = -1 # number of rows in this block-row, -1 indicates unknown
+        for k = 1:rows[i]
+            if !isa(A[j+k], UniformScaling)
+                na = size(A[j+k], 1)
+                ni >= 0 && ni != na &&
+                    throw(DimensionMismatch("mismatch in number of rows"))
+                ni = na
+            end
+        end
+        if ni >= 0
+            for k = 1:rows[i]
+                n[j+k] = ni
+            end
+        else # row consisted only of UniformScaling objects
+            needcols = true
+        end
+        j += rows[i]
+    end
+    if needcols # some sizes still unknown, try to infer from column count
+        nc = -1
+        j = 0
+        for i = 1:nr
+            nci = 0
+            rows[i] > 0 && n[j+1] == -1 && (j += rows[i]; continue)
+            for k = 1:rows[i]
+                nci += isa(A[j+k], UniformScaling) ? n[j+k] : size(A[j+k], 2)
+            end
+            nc >= 0 && nc != nci && throw(DimensionMismatch("mismatch in number of columns"))
+            nc = nci
+            j += rows[i]
+        end
+        nc == -1 && throw(ArgumentError("sizes of UniformScalings could not be inferred"))
+        j = 0
+        for i = 1:nr
+            if rows[i] > 0 && n[j+1] == -1 # this row consists entirely of UniformScalings
+                nci = nc ÷ rows[i]
+                nci * rows[i] != nc && throw(DimensionMismatch("indivisible UniformScaling sizes"))
+                for k = 1:rows[i]
+                    n[j+k] = nci
+                end
+            end
+            j += rows[i]
+        end
+    end
+	As = map(zip(n, A)) do (ni, Ai)
+		if Ai isa UniformScaling
+			return LinearMap{T}(UniformScalingMap(convert(T, Ai.λ), ni))
+		else
+			return LinearMap{T}(Ai) # eltype(Ai) == T ? Ai : LinearMap{T}(Ai)
+		end
+	end
+    return BlockMap(Base.typed_hvcat(WrappedMap{T}, rows,  As...))
+end
+
+############
+# basic methods
+############
+
+function LinearAlgebra.issymmetric(A::BlockMap)
+    m, n = nblocks(A)
+    m == n || return false
+    for i in 1:m, j in i:m
+        if (i == j && !issymmetric(getblock(A, i, i)))
+            return false
+        elseif getblock(A, i, j) != transpose(getblock(A, j, i))
+            return false
+        end
+    end
+    return true
+end
+
+LinearAlgebra.ishermitian(A::BlockMap{<:Real}) = issymmetric(A)
+function LinearAlgebra.ishermitian(A::BlockMap)
+    m, n = nblocks(A)
+    m == n || return false
+    for i in 1:m, j in i:m
+        if (i == j && !ishermitian(getblock(A, i, i)))
+            return false
+        elseif getblock(A, i, j) != adjoint(getblock(A, j, i))
+            return false
+        end
+    end
+    return true
+end
+# TODO, currently falls back on the generic `false`
+# LinearAlgebra.isposdef(A::BlockMap)
+
+############
+# comparison of BlockMap objects, sufficient but not necessary
+############
+
+Base.:(==)(A::BlockMap, B::BlockMap) = (eltype(A) == eltype(B) && A.maps == B.maps)
+
+# special transposition behavior
+
+LinearAlgebra.transpose(A::BlockMap) = BlockMap(transpose(A.maps))
+LinearAlgebra.adjoint(A::BlockMap)   = BlockMap(adjoint(A.maps))
+
+############
+# multiplication with vectors
+############
+
+function A_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+    M, N = size(A)
+    (length(x) == N && length(y) == M) || throw(DimensionMismatch())
+    yinds, xinds = cumulsizes(A.block_sizes)
+    # fill y with results of first block column
+    @inbounds for i in 1:nblocks(A, 1)
+        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], getblock(A, i, 1), x[xinds[1]:xinds[2]-1])
+    end
+    # add to y results of the following block columns
+    @inbounds for j in 2:nblocks(A, 2), i in 1:nblocks(A, 1)
+        @views mul!(y[yinds[i]:yinds[i+1]-1], getblock(A, i, j), x[xinds[j]:xinds[j+1]-1], 1, 1)
+    end
+    return y
+end
+function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+    M, N = size(A)
+    (length(x) == N && length(y) == M) || throw(DimensionMismatch())
+    xinds, yinds = cumulsizes(A.block_sizes)
+    # fill y with results of first block column
+    @inbounds for i in 1:nblocks(A, 2)
+        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], transpose(getblock(A, 1, i)), x[xinds[1]:xinds[2]-1])
+    end
+    # add to y results of the following block columns
+    @inbounds for j in 2:nblocks(A, 1), i in 1:nblocks(A, 2)
+        @views mul!(y[yinds[i]:yinds[i+1]-1], transpose(getblock(A, j, i)), x[xinds[j]:xinds[j+1]-1], 1, 1)
+    end
+    return y
+end
+function Ac_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+	M, N = size(A)
+    (length(x) == N && length(y) == M) || throw(DimensionMismatch())
+    xinds, yinds = cumulsizes(A.block_sizes)
+    # fill y with results of first block column
+    @inbounds for i in 1:nblocks(A, 2)
+        @views A_mul_B!(y[yinds[i]:yinds[i+1]-1], adjoint(getblock(A, 1, i)), x[xinds[1]:xinds[2]-1])
+    end
+    # add to y results of the following block columns
+    @inbounds for j in 2:nblocks(A, 1), i in 1:nblocks(A, 2)
+        @views mul!(y[yinds[i]:yinds[i+1]-1], adjoint(getblock(A, j, i)), x[xinds[j]:xinds[j+1]-1], 1, 1)
+    end
+    return y
+end
+
+############
+# show methods
+############
+
+block2string(b, s) = string(join(map(string, b), '×'), "-blocked ", Base.dims2string(s))
+Base.summary(a::BlockMap) = string(block2string(nblocks(a), size(a)), " ", typeof(a))
+# _show_typeof(io, a) = show(io, typeof(a))
+function Base.summary(io::IO, a::BlockMap)
+    print(io, block2string(nblocks(a), size(a)))
+    print(io, ' ')
+    _show_typeof(io, a)
+end
+function _show_typeof(io::IO, a::BlockMap{T}) where {T}
+    Base.show_type_name(io, typeof(a).name)
+    print(io, '{')
+    show(io, T)
+    print(io, '}')
+end

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -163,10 +163,10 @@ function checksizes(fullsizes::Array{Tuple{Int,Int},2}, block_sizes::Tuple{Vecto
     Base.@nloops 2 i fullsizes begin
         block_index = Base.@ntuple 2 i
         if fullsizes[block_index...] != getsizes(block_sizes, block_index)
-            throw(ArgumentError("size(blocks[", strip(repr(block_index), ['(', ')']),
-                  "]) (= ", fullsizes[block_index...],
-                  ") is incompatible with expected size: ",
-                  getsizes(block_sizes, block_index)))
+			error("size(blocks[", strip(repr(block_index), ['(', ')']),
+                      "]) (= ", fullsizes[block_index...],
+                      ") is incompatible with expected size: ",
+                      getsizes(block_sizes, block_index))
         end
     end
     return fullsizes

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -6,9 +6,7 @@ struct BlockMap{T,As<:Tuple{Vararg{LinearMap}},Rs<:Tuple{Vararg{Int}}} <: Linear
     end
 end
 
-cumsize_h(maps::Tuple{Vararg{LinearMap}}) = cumsum([1, map(m -> size(m, 2), maps)...,])
-
-cumsize_v(maps::Tuple{Vararg{LinearMap}}) = cumsum([1, map(m -> size(m, 1), maps)...,])
+firstindices(maps::Tuple{Vararg{LinearMap}}, dim) = cumsum([1, map(m -> size(m, dim), maps)...,])
 
 function check_dims(maps::Tuple{Vararg{LinearMap}}, k)
     n = size(maps[1], k)
@@ -215,9 +213,9 @@ LinearAlgebra.adjoint(A::BlockMap)  = AdjointMap(A)
 function A_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     maps, rows = A.maps, A.rows
     mapind = 0
-    yinds = cumsize_v(maps[cumsum([1, rows...])[1:end-1]])
+    yinds = firstindices(maps[cumsum([1, rows...])[1:end-1]], 1)
     @views for rowind in 1:length(rows)
-        xinds = cumsize_h(maps[mapind+1:mapind+rows[rowind]])
+        xinds = firstindices(maps[mapind+1:mapind+rows[rowind]], 2)
         yrow = @views y[yinds[rowind]:(yinds[rowind+1]-1)]
         mapind += 1
         A_mul_B!(yrow, maps[mapind], x[xinds[1]:xinds[2]-1])
@@ -233,9 +231,9 @@ function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     maps, rows = A.maps, A.rows
     fill!(y, 0)
     mapind = 0
-    xinds = cumsize_v(maps[cumsum([1, rows...])[1:end-1]])
+    xinds = firstindices(maps[cumsum([1, rows...])[1:end-1]], 1)
     # first block row (rowind = 1), fill all of y
-    yinds = cumsize_h(maps[mapind+1:mapind+rows[1]])
+    yinds = firstindices(maps[mapind+1:mapind+rows[1]], 2)
     xcol = @views x[xinds[1]:(xinds[2]-1)]
     @views for colind in 1:rows[1]
         mapind +=1
@@ -243,7 +241,7 @@ function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     end
     # subsequent block rows, add results to corresponding parts of y
     @views for rowind in 2:length(rows)
-        yinds = cumsize_h(maps[mapind+1:mapind+rows[rowind]])
+        yinds = firstindices(maps[mapind+1:mapind+rows[rowind]], 2)
         xcol = @views x[xinds[rowind]:(xinds[rowind+1]-1)]
         for colind in 1:rows[rowind]
             mapind +=1
@@ -257,9 +255,9 @@ function Ac_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     maps, rows = A.maps, A.rows
     fill!(y, 0)
     mapind = 0
-    xinds = cumsize_v(maps[cumsum([1, rows...])[1:end-1]])
+    xinds = firstindices(maps[cumsum([1, rows...])[1:end-1]], 1)
     # first block row (rowind = 1), fill all of y
-    yinds = cumsize_h(maps[mapind+1:mapind+rows[1]])
+    yinds = firstindices(maps[mapind+1:mapind+rows[1]], 2)
     xcol = @views x[xinds[1]:(xinds[2]-1)]
     @views for colind in 1:rows[1]
         mapind +=1
@@ -267,7 +265,7 @@ function Ac_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     end
     # subsequent block rows, add results to corresponding parts of y
     @views for rowind in 2:length(rows)
-        yinds = cumsize_h(maps[mapind+1:mapind+rows[rowind]])
+        yinds = firstindices(maps[mapind+1:mapind+rows[rowind]], 2)
         xcol = @views x[xinds[rowind]:(xinds[rowind+1]-1)]
         for colind in 1:rows[rowind]
             mapind +=1

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -24,18 +24,18 @@ HBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = HBlockMap(maps, sizes_f
 VBlockMap(maps::Tuple{Vararg{LinearMap{T}}}) where {T} = VBlockMap(maps, sizes_from_maps_v(maps))
 
 function sizes_from_maps_h(maps::Tuple{Vararg{LinearMap}})::Tuple{Vector{Int},Vector{Int}} where {T}
-	m = size(maps[1], 1)
-	for map in maps
-		m == size(map, 1) || throw(DimensionMismatch())
-	end
-	return [1, m+1], cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 2), maps)...,])
+    m = size(maps[1], 1)
+    for map in maps
+        m == size(map, 1) || throw(DimensionMismatch())
+    end
+    return [1, m+1], cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 2), maps)...,])
 end
 function sizes_from_maps_v(maps::Tuple{Vararg{LinearMap}})::Tuple{Vector{Int},Vector{Int}} where {T}
-	n = size(maps[1], 2)
-	for map in maps
-		n == size(map, 2) || throw(DimensionMismatch())
-	end
-	return cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 1), maps)...,]), [1, n+1]
+    n = size(maps[1], 2)
+    for map in maps
+        n == size(map, 2) || throw(DimensionMismatch())
+    end
+    return cumsum!(zeros(Int, length(maps)+1), [1, map(m -> size(m, 1), maps)...,]), [1, n+1]
 end
 
 @inline Base.size(A::AbstractBlockMap) = (A.block_sizes[1][end]-1, A.block_sizes[2][end]-1)
@@ -45,32 +45,32 @@ end
 ############
 
 function Base.hcat(As::Union{LinearMap,UniformScaling}...)
-	T = promote_type(map(eltype, As)...)
-	for A in As
-		if !(A isa UniformScaling)
-			eltype(A) == T || throw(ArgumentError("eltype mismatch in hcat of linear maps"))
-		end
-	end
+    T = promote_type(map(eltype, As)...)
+    for A in As
+        if !(A isa UniformScaling)
+            eltype(A) == T || throw(ArgumentError("eltype mismatch in hcat of linear maps"))
+        end
+    end
 
-	nrows = 0
-	# find first non-UniformScaling to detect number of rows
-	for A in As
-		if !(A isa UniformScaling)
-			nrows = size(A, 1)
-			break
-		end
-	end
-	nrows == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
+    nrows = 0
+    # find first non-UniformScaling to detect number of rows
+    for A in As
+        if !(A isa UniformScaling)
+            nrows = size(A, 1)
+            break
+        end
+    end
+    nrows == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
 
-	maps = map(As) do A
-		if A isa UniformScaling
-			return UniformScalingMap(convert(T, A.λ), nrows)
-		else
-			# size(A, 1) == nrows || throw(DimensionMismatch("hcat of LinearMaps"))
-			return A
-		end
-	end
-	return hcat(maps...)
+    maps = map(As) do A
+        if A isa UniformScaling
+            return UniformScalingMap(convert(T, A.λ), nrows)
+        else
+            # size(A, 1) == nrows || throw(DimensionMismatch("hcat of LinearMaps"))
+            return A
+        end
+    end
+    return hcat(maps...)
 end
 Base.hcat(A::LinearMap{T}, As::LinearMap{T}...) where {T} = hcat(A, hcat(As...))
 Base.hcat(A::LinearMap{T}, B::LinearMap{T}) where {T} = HBlockMap(tuple(A, B))
@@ -78,32 +78,32 @@ Base.hcat(A::LinearMap{T}, B::HBlockMap{T}) where {T} = HBlockMap(tuple(A, B.map
 Base.hcat(A::HBlockMap{T}, B::HBlockMap{T}) where {T} = HBlockMap(tuple(A.maps..., B.maps...))
 
 function Base.vcat(As::Union{LinearMap,UniformScaling}...)
-	T = promote_type(map(eltype, As)...)
-	for A in As
-		if !(A isa UniformScaling)
-			eltype(A) == T || throw(ArgumentError("eltype type mismatch in vcat of linear maps"))
-		end
-	end
+    T = promote_type(map(eltype, As)...)
+    for A in As
+        if !(A isa UniformScaling)
+            eltype(A) == T || throw(ArgumentError("eltype type mismatch in vcat of linear maps"))
+        end
+    end
 
-	ncols = 0
-	# find first non-UniformScaling to detect number of columns
-	for A in As
-		if !(A isa UniformScaling)
-			ncols = size(A, 2)
-			break
-		end
-	end
-	ncols == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
+    ncols = 0
+    # find first non-UniformScaling to detect number of columns
+    for A in As
+        if !(A isa UniformScaling)
+            ncols = size(A, 2)
+            break
+        end
+    end
+    ncols == 0 && throw(ArgumentError("hcat of only UniformScaling-like objects cannot determine the linear map size"))
 
-	maps = map(As) do A
-		if A isa UniformScaling
-			return UniformScalingMap(convert(T, A.λ), ncols)
-		else
-			# size(A, 2) == ncols || throw(DimensionMismatch("vcat of LinearMaps"))
-			return A
-		end
-	end
-	return vcat(maps...)
+    maps = map(As) do A
+        if A isa UniformScaling
+            return UniformScalingMap(convert(T, A.λ), ncols)
+        else
+            # size(A, 2) == ncols || throw(DimensionMismatch("vcat of LinearMaps"))
+            return A
+        end
+    end
+    return vcat(maps...)
 end
 Base.vcat(A::LinearMap{T}, As::LinearMap{T}...) where {T} = vcat(A, vcat(As...))
 Base.vcat(A::LinearMap{T}, B::LinearMap{T}) where {T} = VBlockMap(tuple(A, B))
@@ -111,7 +111,7 @@ Base.vcat(A::LinearMap{T}, B::VBlockMap{T}) where {T} = VBlockMap(tuple(A, B.map
 Base.vcat(A::VBlockMap{T}, B::VBlockMap{T}) where {T} = VBlockMap(tuple(A.maps..., B.maps...))
 
 function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling}...)
-	T = promote_type(map(eltype, As)...)
+    T = promote_type(map(eltype, As)...)
     nr = length(rows)
     sum(rows) == length(As) || throw(ArgumentError("mismatch between row sizes and number of arguments"))
     n = fill(-1, length(As))
@@ -162,23 +162,23 @@ function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling
             j += rows[i]
         end
     end
-	maps = ntuple(length(As)) do i
-		if As[i] isa UniformScaling
-			return UniformScalingMap(convert(T, As[i].λ), n[i])
-		else
-			return As[i] # size check is going to be performed in h/v/cat below
-		end
-	end
+    maps = ntuple(length(As)) do i
+        if As[i] isa UniformScaling
+            return UniformScalingMap(convert(T, As[i].λ), n[i])
+        else
+            return As[i] # size check is going to be performed in h/v/cat below
+        end
+    end
 
-	return hvcat(rows, maps)
+    return hvcat(rows, maps)
 end
 function Base.hvcat(rows::Tuple{Vararg{Int}}, As::Tuple{Vararg{LinearMap{T}}}) where {T}
-	nr = length(rows)
-	j = 0
-	A::NTuple{nr,HBlockMap{T}} = ntuple(nr) do i
-		hmaps = As[j+1:j+rows[i]]
-		j += rows[i]
-		return hcat(hmaps...)
+    nr = length(rows)
+    j = 0
+    A::NTuple{nr,HBlockMap{T}} = ntuple(nr) do i
+        hmaps = As[j+1:j+rows[i]]
+        j += rows[i]
+        return hcat(hmaps...)
     end
 
     return vcat(A...)
@@ -239,19 +239,19 @@ function A_mul_B!(y::AbstractVector, A::HBlockMap, x::AbstractVector)
     (length(x) == N && length(y) == M) || throw(DimensionMismatch())
     _, xinds = A.block_sizes
     # fill y with results of first block
-	A_mul_B!(y, A.maps[1], @views x[xinds[1]:xinds[2]-1])
-	# add to y results of the following block columns
+    A_mul_B!(y, A.maps[1], @views x[xinds[1]:xinds[2]-1])
+    # add to y results of the following block columns
     @inbounds @views for j in 2:length(A.maps)
         mul!(y, A.maps[j], x[xinds[j]:xinds[j+1]-1], 1, 1)
     end
     return y
 end
 function A_mul_B!(y::AbstractVector, A::VBlockMap, x::AbstractVector)
-	M, N = size(A)
+    M, N = size(A)
     (length(x) == N && length(y) == M) || throw(DimensionMismatch())
     yinds, _ = A.block_sizes
     # fill parts of y according to block sizes
-	@inbounds @views for j in 1:length(A.maps)
+    @inbounds @views for j in 1:length(A.maps)
         A_mul_B!(y[yinds[j]:yinds[j+1]-1], A.maps[j], x)
     end
     return y

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -163,10 +163,10 @@ function checksizes(fullsizes::Array{Tuple{Int,Int},2}, block_sizes::Tuple{Vecto
     Base.@nloops 2 i fullsizes begin
         block_index = Base.@ntuple 2 i
         if fullsizes[block_index...] != getsizes(block_sizes, block_index)
-            error("size(blocks[", strip(repr(block_index), ['(', ')']),
+            throw(ArgumentError("size(blocks[", strip(repr(block_index), ['(', ')']),
                   "]) (= ", fullsizes[block_index...],
                   ") is incompatible with expected size: ",
-                  getsizes(block_sizes, block_index))
+                  getsizes(block_sizes, block_index)))
         end
     end
     return fullsizes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -505,6 +505,14 @@ end
             @test size(L) == (30, 30)
             @test Matrix(L) ≈ A
             @test L * x ≈ A * x
+            A = rand(elty, 10,10); LA = LinearMap(A)
+            B = rand(elty, 20,30); LB = LinearMap(B)
+            @test [LA LA LA; LB] isa LinearMaps.AbstractBlockMap{elty}
+            @test Matrix([LA LA LA; LB]) ≈ [A A A; B]
+            @test [LB; LA LA LA] isa LinearMaps.AbstractBlockMap{elty}
+            @test Matrix([LB; LA LA LA]) ≈ [B; A A A]
+            @test [I; LA LA LA] isa LinearMaps.AbstractBlockMap{elty}
+            @test Matrix([I; LA LA LA]) ≈ [I; A A A]
             A12 = rand(elty, 10, 21)
             A21 = rand(elty, 20, 10)
             @test_throws ArgumentError A = [I A12; A21 I]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -456,6 +456,9 @@ end
             x = rand(elty, 60)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
+            A11 = rand(elty, 11, 10)
+            A12 = rand(elty, 10, 20)
+            @test_throws ArgumentError hcat(LinearMap(A11), LinearMap(A12))
         end
     end
     @testset "vcat" begin
@@ -472,6 +475,9 @@ end
             x = rand(elty, 10)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
+            A11 = rand(elty, 10, 11)
+            A21 = rand(elty, 20, 10)
+            @test_throws ArgumentError vcat(LinearMap(A11), LinearMap(A21))
         end
     end
     @testset "hvcat" begin
@@ -485,6 +491,10 @@ end
             @test L isa LinearMaps.BlockMap{elty}
             @test size(L) == (30, 30)
             @test L * x ≈ A * x
+            A12 = rand(elty, 10, 21)
+            A21 = rand(elty, 20, 10)
+            @test_throws ArgumentError A = [I A12; A21 I]
+            @test_throws ArgumentError A = [A12 A12; A21 A21]
         end
     end
     @testset "adjoint/transpose" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,7 +447,7 @@ end
             A11 = rand(elty, 10, 10)
             A12 = rand(elty, 10, 20)
             L = @inferred hcat(LinearMap(A11), LinearMap(A12))
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.BlockMap{elty}
             A = [A11 A12]
             x = rand(30)
             @test size(L) == size(A)
@@ -456,7 +456,7 @@ end
             A = [I I I A11 A11 A11]
             L = [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11)]
             x = rand(elty, 60)
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
             A11 = rand(elty, 11, 10)
             A12 = rand(elty, 10, 20)
@@ -468,7 +468,7 @@ end
             A11 = rand(elty, 10, 10)
             A21 = rand(elty, 20, 10)
             L = @inferred vcat(LinearMap(A11), LinearMap(A21))
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.BlockMap{elty}
             A = [A11; A21]
             x = rand(10)
             @test size(L) == size(A)
@@ -477,7 +477,7 @@ end
             A = [I; I; I; A11; A11; A11]
             L = [I; I; I; LinearMap(A11); LinearMap(A11); LinearMap(A11)]
             x = rand(elty, 10)
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
             A11 = rand(elty, 10, 11)
             A21 = rand(elty, 20, 10)
@@ -491,27 +491,27 @@ end
             A21 = rand(elty, 20, 10)
             A22 = rand(elty, 20, 20)
             A = [A11 A12; A21 A22]
-            @test @inferred hvcat(2, LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
+            @inferred hvcat((2,2), LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
             L = [LinearMap(A11) LinearMap(A12); LinearMap(A21) LinearMap(A22)]
             x = rand(30)
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.BlockMap{elty}
             @test size(L) == size(A)
             @test L * x ≈ A * x
             @test Matrix(L) ≈ A
             A = [I A12; A21 I]
-            @test @inferred hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
-            L = hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @inferred hvcat((2,2), I, LinearMap(A12), LinearMap(A21), I)
+            L = @inferred hvcat((2,2), I, LinearMap(A12), LinearMap(A21), I)
+            @test L isa LinearMaps.BlockMap{elty}
             @test size(L) == (30, 30)
             @test Matrix(L) ≈ A
             @test L * x ≈ A * x
             A = rand(elty, 10,10); LA = LinearMap(A)
             B = rand(elty, 20,30); LB = LinearMap(B)
-            @test [LA LA LA; LB] isa LinearMaps.AbstractBlockMap{elty}
+            @test [LA LA LA; LB] isa LinearMaps.BlockMap{elty}
             @test Matrix([LA LA LA; LB]) ≈ [A A A; B]
-            @test [LB; LA LA LA] isa LinearMaps.AbstractBlockMap{elty}
+            @test [LB; LA LA LA] isa LinearMaps.BlockMap{elty}
             @test Matrix([LB; LA LA LA]) ≈ [B; A A A]
-            @test [I; LA LA LA] isa LinearMaps.AbstractBlockMap{elty}
+            @test [I; LA LA LA] isa LinearMaps.BlockMap{elty}
             @test Matrix([I; LA LA LA]) ≈ [I; A A A]
             A12 = rand(elty, 10, 21)
             A21 = rand(elty, 20, 10)
@@ -526,12 +526,12 @@ end
             L = [I LinearMap(A12); transform(LinearMap(A12)) I]
             @test_broken ishermitian(L)
             x = rand(elty, 20)
-            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test L isa LinearMaps.LinearMap{elty}
             @test size(L) == size(A)
             @test L * x ≈ A * x
             @test Matrix(L) ≈ A
             Lt = transform(L)
-            @test Lt isa LinearMaps.AbstractBlockMap{elty}
+            @test Lt isa LinearMaps.LinearMap{elty}
             @test Lt * x ≈ transform(A) * x
             Lt = transform(LinearMap(L))
             @test Lt * x ≈ transform(A) * x
@@ -540,7 +540,7 @@ end
             A = [I A12; A21 I]
             L = [I LinearMap(A12); LinearMap(A21) I]
             Lt = transform(L)
-            @test Lt isa LinearMaps.AbstractBlockMap{elty}
+            @test Lt isa LinearMaps.LinearMap{elty}
             @test Lt * x ≈ transform(A) * x
             @test Matrix(Lt) ≈ Matrix(transform(A))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -447,18 +447,18 @@ end
             A11 = rand(elty, 10, 10)
             A12 = rand(elty, 10, 20)
             L = @inferred hcat(LinearMap(A11), LinearMap(A12))
-            @test L isa LinearMaps.BlockMap{elty}
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             A = [A11 A12]
             x = rand(30)
             @test L * x ≈ A * x
             A = [I I I A11 A11 A11]
             L = [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11)]
             x = rand(elty, 60)
-            @test L isa LinearMaps.BlockMap{elty}
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             @test L * x ≈ A * x
             A11 = rand(elty, 11, 10)
             A12 = rand(elty, 10, 20)
-            @test_throws ErrorException hcat(LinearMap(A11), LinearMap(A12))
+            @test_throws DimensionMismatch hcat(LinearMap(A11), LinearMap(A12))
         end
     end
     @testset "vcat" begin
@@ -466,29 +466,38 @@ end
             A11 = rand(elty, 10, 10)
             A21 = rand(elty, 20, 10)
             L = @inferred vcat(LinearMap(A11), LinearMap(A21))
-            @test L isa LinearMaps.BlockMap{elty}
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             A = [A11; A21]
             x = rand(10)
             @test L * x ≈ A * x
             A = [I; I; I; A11; A11; A11]
             L = [I; I; I; LinearMap(A11); LinearMap(A11); LinearMap(A11)]
             x = rand(elty, 10)
-            @test L isa LinearMaps.BlockMap{elty}
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             @test L * x ≈ A * x
             A11 = rand(elty, 10, 11)
             A21 = rand(elty, 20, 10)
-            @test_throws ErrorException vcat(LinearMap(A11), LinearMap(A21))
+            @test_throws DimensionMismatch vcat(LinearMap(A11), LinearMap(A21))
         end
     end
     @testset "hvcat" begin
         for elty in (Float32, Float64, ComplexF64)
+            A11 = rand(elty, 10, 10)
             A12 = rand(elty, 10, 20)
             A21 = rand(elty, 20, 10)
+            A22 = rand(elty, 20, 20)
+            A = [A11 A12; A21 A22]
+            @test_broken @inferred hvcat(2, LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
+            L = [LinearMap(A11) LinearMap(A12); LinearMap(A21) LinearMap(A22)]
+            x = rand(30)
+            @test L isa LinearMaps.AbstractBlockMap{elty}
+            @test size(L) == (30, 30)
+            @test L * x ≈ A * x
+            @test Matrix(L) ≈ A
             A = [I A12; A21 I]
             @test_broken @inferred hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
-            L = [I LinearMap(A12); LinearMap(A21) I]
-            x = rand(30)
-            @test L isa LinearMaps.BlockMap{elty}
+            L = hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             @test size(L) == (30, 30)
             @test L * x ≈ A * x
             A12 = rand(elty, 10, 21)
@@ -504,11 +513,11 @@ end
             L = [I LinearMap(A12); transform(LinearMap(A12)) I]
             @test_broken ishermitian(L)
             x = rand(elty, 20)
-            @test L isa LinearMaps.BlockMap{elty}
+            @test L isa LinearMaps.AbstractBlockMap{elty}
             @test size(L) == (20, 20)
             @test L * x ≈ A * x
             Lt = transform(L)
-            @test Lt isa LinearMaps.BlockMap{elty}
+            @test Lt isa LinearMaps.AbstractBlockMap{elty}
             @test Lt * x ≈ transform(A) * x
             Lt = transform(LinearMap(L))
             @test Lt * x ≈ transform(A) * x
@@ -516,7 +525,7 @@ end
             A = [I A12; A21 I]
             L = [I LinearMap(A12); LinearMap(A21) I]
             Lt = transform(L)
-            @test Lt isa LinearMaps.BlockMap{elty}
+            @test Lt isa LinearMaps.AbstractBlockMap{elty}
             @test Lt * x ≈ transform(A) * x
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -458,7 +458,7 @@ end
             @test L * x ≈ A * x
             A11 = rand(elty, 11, 10)
             A12 = rand(elty, 10, 20)
-            @test_throws ArgumentError hcat(LinearMap(A11), LinearMap(A12))
+            @test_throws ErrorException hcat(LinearMap(A11), LinearMap(A12))
         end
     end
     @testset "vcat" begin
@@ -477,7 +477,7 @@ end
             @test L * x ≈ A * x
             A11 = rand(elty, 10, 11)
             A21 = rand(elty, 20, 10)
-            @test_throws ArgumentError vcat(LinearMap(A11), LinearMap(A21))
+            @test_throws ErrorException vcat(LinearMap(A11), LinearMap(A21))
         end
     end
     @testset "hvcat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -487,7 +487,7 @@ end
             A21 = rand(elty, 20, 10)
             A22 = rand(elty, 20, 20)
             A = [A11 A12; A21 A22]
-            @test_broken @inferred hvcat(2, LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
+            @test @inferred hvcat(2, LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
             L = [LinearMap(A11) LinearMap(A12); LinearMap(A21) LinearMap(A22)]
             x = rand(30)
             @test L isa LinearMaps.AbstractBlockMap{elty}
@@ -495,7 +495,7 @@ end
             @test L * x ≈ A * x
             @test Matrix(L) ≈ A
             A = [I A12; A21 I]
-            @test_broken @inferred hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
+            @test @inferred hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
             L = hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
             @test L isa LinearMaps.AbstractBlockMap{elty}
             @test size(L) == (30, 30)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -453,8 +453,12 @@ end
             @test size(L) == size(A)
             @test Matrix(L) ≈ A
             @test L * x ≈ A * x
+            L = @inferred hcat(LinearMap(A11), LinearMap(A12), LinearMap(A11))
+            A = [A11 A12 A11]
+            @test Matrix(L) ≈ A
             A = [I I I A11 A11 A11]
-            L = [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11)]
+            L = @inferred hcat(I, I, I, LinearMap(A11), LinearMap(A11), LinearMap(A11))
+            @test L == [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11)]
             x = rand(elty, 60)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
@@ -466,6 +470,9 @@ end
     @testset "vcat" begin
         for elty in (Float32, Float64, ComplexF64)
             A11 = rand(elty, 10, 10)
+            L = @inferred vcat(LinearMap(A11))
+            @test L == [LinearMap(A11);]
+            @test Matrix(L) ≈ A11
             A21 = rand(elty, 20, 10)
             L = @inferred vcat(LinearMap(A11), LinearMap(A21))
             @test L isa LinearMaps.BlockMap{elty}
@@ -475,7 +482,8 @@ end
             @test Matrix(L) ≈ A
             @test L * x ≈ A * x
             A = [I; I; I; A11; A11; A11]
-            L = [I; I; I; LinearMap(A11); LinearMap(A11); LinearMap(A11)]
+            L = @inferred vcat(I, I, I, LinearMap(A11), LinearMap(A11), LinearMap(A11))
+            @test L == [I; I; I; LinearMap(A11); LinearMap(A11); LinearMap(A11)]
             x = rand(elty, 10)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -450,6 +450,8 @@ end
             @test L isa LinearMaps.AbstractBlockMap{elty}
             A = [A11 A12]
             x = rand(30)
+            @test size(L) == size(A)
+            @test Matrix(L) ≈ A
             @test L * x ≈ A * x
             A = [I I I A11 A11 A11]
             L = [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11)]
@@ -469,6 +471,8 @@ end
             @test L isa LinearMaps.AbstractBlockMap{elty}
             A = [A11; A21]
             x = rand(10)
+            @test size(L) == size(A)
+            @test Matrix(L) ≈ A
             @test L * x ≈ A * x
             A = [I; I; I; A11; A11; A11]
             L = [I; I; I; LinearMap(A11); LinearMap(A11); LinearMap(A11)]
@@ -491,7 +495,7 @@ end
             L = [LinearMap(A11) LinearMap(A12); LinearMap(A21) LinearMap(A22)]
             x = rand(30)
             @test L isa LinearMaps.AbstractBlockMap{elty}
-            @test size(L) == (30, 30)
+            @test size(L) == size(A)
             @test L * x ≈ A * x
             @test Matrix(L) ≈ A
             A = [I A12; A21 I]
@@ -499,6 +503,7 @@ end
             L = hvcat(2, I, LinearMap(A12), LinearMap(A21), I)
             @test L isa LinearMaps.AbstractBlockMap{elty}
             @test size(L) == (30, 30)
+            @test Matrix(L) ≈ A
             @test L * x ≈ A * x
             A12 = rand(elty, 10, 21)
             A21 = rand(elty, 20, 10)
@@ -514,19 +519,22 @@ end
             @test_broken ishermitian(L)
             x = rand(elty, 20)
             @test L isa LinearMaps.AbstractBlockMap{elty}
-            @test size(L) == (20, 20)
+            @test size(L) == size(A)
             @test L * x ≈ A * x
+            @test Matrix(L) ≈ A
             Lt = transform(L)
             @test Lt isa LinearMaps.AbstractBlockMap{elty}
             @test Lt * x ≈ transform(A) * x
             Lt = transform(LinearMap(L))
             @test Lt * x ≈ transform(A) * x
+            @test Matrix(Lt) ≈ Matrix(transform(A))
             A21 = rand(elty, 10, 10)
             A = [I A12; A21 I]
             L = [I LinearMap(A12); LinearMap(A21) I]
             Lt = transform(L)
             @test Lt isa LinearMaps.AbstractBlockMap{elty}
             @test Lt * x ≈ transform(A) * x
+            @test Matrix(Lt) ≈ Matrix(transform(A))
         end
     end
 end


### PR DESCRIPTION
Here are tested block maps.

The block index logic is shamelessly adopted from BlockArrays, the `*cat` logic is from `Base.uniformscaling.jl`. This allows to block concatenate `LinearMaps` and `UniformScalings`, matrices need to be wrapped by `LinearMap` first (otherwise, overwriting `*cat` ends up as type piracy). Block `LinearMap`s are stored in an array of LinearMaps, on which the block index logic works nicely. The only drawback is that to have the eltype concrete, I need to wrap all `LinearMap`s as `WrappedMap`s. This makes it impossible to identify symmetry from the block structure automatically, because all the wrapping layers hide that possibly one map is the adjoint of another. For the time being, I think this is of little harm, because, for a known symmetric/hermitian operator, one can always wrap it once more in a LinearMap and mark it as symmetric/hermitian. Another little issue is that `hvcat` is currently not type-stable. Anyway, we have generic tests now, which will help further development. I just realized I should probably add some failing tests for incompatible sizes...

EDIT: closes #45.