### PR TITLE
Simplify multiplication code

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -47,8 +47,8 @@ end
 # the following is of interest in, e.g., subspace-iteration methods
 function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap{T}, X::AbstractMatrix, α::Number=one(T), β::Number=zero(T)) where {T}
     (size(Y, 1) == size(A, 1) && size(X, 1) == size(A, 2) && size(Y, 2) == size(X, 2)) || throw(DimensionMismatch("mul!"))
-    @inbounds @views for i = 1:size(X, 2)
-        mul!(Y[:, i], A, X[:, i], α, β)
+    for (Xi, Yi) in zip(eachcol(X), eachcol(Y))
+        mul!(Yi, A, Xi, α, β)
     end
     return Y
 end

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -47,9 +47,13 @@ end
 # the following is of interest in, e.g., subspace-iteration methods
 function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap{T}, X::AbstractMatrix, α::Number=one(T), β::Number=zero(T)) where {T}
     (size(Y, 1) == size(A, 1) && size(X, 1) == size(A, 2) && size(Y, 2) == size(X, 2)) || throw(DimensionMismatch("mul!"))
-    for (Xi, Yi) in zip(eachcol(X), eachcol(Y))
-        mul!(Yi, A, Xi, α, β)
+    @inbounds @views for i = 1:size(X, 2)
+        mul!(Y[:, i], A, X[:, i], α, β)
     end
+    # starting from Julia v1.1, we could use the `eachcol` iterator
+    # for (Xi, Yi) in zip(eachcol(X), eachcol(Y))
+    #     mul!(Yi, A, Xi, α, β)
+    # end
     return Y
 end
 

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -131,63 +131,7 @@ function A_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
     end
     return y
 end
-function At_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
-    # no size checking, will be done by individual maps
-    N = length(A.maps)
-    if N == 1
-        At_mul_B!(y, A.maps[1], x)
-    else
-        T = eltype(y)
-        dest = Array{T}(undef, size(A.maps[N], 2))
-        At_mul_B!(dest, A.maps[N], x)
-        source = dest
-        if N>2
-            dest = Array{T}(undef, size(A.maps[N-1], 2))
-        end
-        for n = N-1:-1:2
-            try
-                resize!(dest, size(A.maps[n], 2))
-            catch err
-                if err == ErrorException("cannot resize array with shared data")
-                    dest = Array{T}(undef, size(A.maps[n], 2))
-                else
-                    rethrow(err)
-                end
-            end
-            At_mul_B!(dest, A.maps[n], source)
-            dest, source = source, dest # alternate dest and source
-        end
-        At_mul_B!(y, A.maps[1], source)
-    end
-    return y
-end
-function Ac_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector)
-    # no size checking, will be done by individual maps
-    N = length(A.maps)
-    if N == 1
-        Ac_mul_B!(y, A.maps[1], x)
-    else
-        T = eltype(y)
-        dest = Array{T}(undef, size(A.maps[N], 2))
-        Ac_mul_B!(dest, A.maps[N], x)
-        source = dest
-        if N>2
-            dest = Array{T}(undef, size(A.maps[N-1], 2))
-        end
-        for n = N-1:-1:2
-            try
-                resize!(dest, size(A.maps[n], 2))
-            catch err
-                if err == ErrorException("cannot resize array with shared data")
-                    dest = Array{T}(undef, size(A.maps[n], 2))
-                else
-                    rethrow(err)
-                end
-            end
-            Ac_mul_B!(dest, A.maps[n], source)
-            dest, source = source, dest # alternate dest and source
-        end
-        Ac_mul_B!(y, A.maps[1], source)
-    end
-    return y
-end
+
+At_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector) = A_mul_B!(y, transpose(A), x)
+
+Ac_mul_B!(y::AbstractVector, A::CompositeMap, x::AbstractVector) = A_mul_B!(y, adjoint(A), x)

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -38,11 +38,6 @@ ismutating(A::FunctionMap) = A._ismutating
 _ismutating(f) = first(methods(f)).nargs == 3
 
 # multiplication with vector
-function A_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
-    (length(x) == A.N && length(y) == A.M) || throw(DimensionMismatch())
-    ismutating(A) ? A.f(y, x) : copyto!(y, A.f(x))
-    return y
-end
 function Base.:(*)(A::FunctionMap, x::AbstractVector)
     length(x) == A.N || throw(DimensionMismatch())
     if ismutating(A)
@@ -51,6 +46,12 @@ function Base.:(*)(A::FunctionMap, x::AbstractVector)
     else
         y = A.f(x)
     end
+    return y
+end
+
+function A_mul_B!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
+    (length(x) == A.N && length(y) == A.M) || throw(DimensionMismatch())
+    ismutating(A) ? A.f(y, x) : copyto!(y, A.f(x))
     return y
 end
 

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -59,29 +59,7 @@ function A_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector)
     end
     return y
 end
-function At_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector)
-    # no size checking, will be done by individual maps
-    At_mul_B!(y, A.maps[1], x)
-    l = length(A.maps)
-    if l>1
-        z = similar(y)
-        for n = 2:l
-            At_mul_B!(z, A.maps[n], x)
-            y .+= z
-        end
-    end
-    return y
-end
-function Ac_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector)
-    # no size checking, will be done by individual maps
-    Ac_mul_B!(y, A.maps[1], x)
-    l = length(A.maps)
-    if l>1
-        z = similar(y)
-        for n=2:l
-            Ac_mul_B!(z, A.maps[n], x)
-            y .+= z
-        end
-    end
-    return y
-end
+
+At_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = A_mul_B!(y, transpose(A), x)
+
+Ac_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = A_mul_B!(y, adjoint(A), x)

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -40,4 +40,4 @@ Base.:(-)(A1::LinearMap, A2::AbstractMatrix) = -(A1, WrappedMap(A2))
 Base.:(-)(A1::AbstractMatrix, A2::LinearMap) = -(WrappedMap(A1), A2)
 
 Base.:(*)(A1::LinearMap, A2::AbstractMatrix) = *(A1, WrappedMap(A2))
-Base.:(*)(A1::AbstractMatrix, A2::LinearMap) = *(WrappedMap(A1) ,A2)
+Base.:(*)(A1::AbstractMatrix, A2::LinearMap) = *(WrappedMap(A1), A2)


### PR DESCRIPTION
This PR reduces multiplication code for types that are "invariant" under adjoint/transpose, analogous to what @Jutho suggested in #49 for `UniformScalingMap`s.

In the subspace-mul, I use Julia Base's `eachcol` function, which creates an iterator over column views.