### PR TITLE
Optimize block map construction and multiplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+  - 1.3
   - nightly
 
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearMaps"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 A Julia package for defining and working with linear maps, also known as linear transformations or linear operators acting on vectors. The only requirement for a LinearMap is that it can act on a vector (by multiplication) efficiently.
 
+## What's new in v2.5.0
+*   New feature: concatenation of `LinearMap`s objects with `UniformScaling`s,
+    consistent with (h-, v-, and hc-)concatenation of matrices. Note, matrices
+    `A` must be wrapped as `LinearMap(A)`, `UniformScaling`s are promoted to
+    `LinearMap`s automatically.
+
+## What's new in v2.4.0
+*   Support restricted to Julia v1.0+.
+
 ## What's new in v2.3.0
 *   Fully Julia v0.7/v1.0/v1.1 compatible.
 *   Full support of noncommutative number types such as quaternions.
@@ -88,6 +97,10 @@ The LinearMaps package provides the following functionality:
     * `mul!(y::AbstractVector, A::LinearMap, x::AbstractVector, α::Number=1, β::Number=0)`: computes `α * A * x + β * y` and stores the result in `y`. Analogously for `X,Y::AbstractMatrix`.
 
     Applying the adjoint or transpose of `A` (if defined) to `x` works exactly as in the usual matrix case: `transpose(A) * x` and `mul!(y, A', x)`, for instance.
+
+*   Horizontal, vertical, and hv-concatenation as known for regular matrices,
+    where `UniformScaling`s are automatically promoted to `LinearMap`s and their
+    sizes are inferred, if possible.
 
 ## Types
 

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -215,7 +215,7 @@ function A_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     yinds = firstrowindices(A)
     @views for rowind in 1:length(rows)
         xinds = firstcolindices(maps[mapind+1:mapind+rows[rowind]])
-        yrow = @views y[yinds[rowind]:(yinds[rowind+1]-1)]
+        yrow = y[yinds[rowind]:(yinds[rowind+1]-1)]
         mapind += 1
         A_mul_B!(yrow, maps[mapind], x[xinds[1]:xinds[2]-1])
         for colind in 2:rows[rowind]
@@ -241,7 +241,7 @@ function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     # subsequent block rows, add results to corresponding parts of y
     @views for rowind in 2:length(rows)
         yinds = firstcolindices(maps[mapind+1:mapind+rows[rowind]])
-        xcol = @views x[xinds[rowind]:(xinds[rowind+1]-1)]
+        xcol = x[xinds[rowind]:(xinds[rowind+1]-1)]
         for colind in 1:rows[rowind]
             mapind +=1
             mul!(y[yinds[colind]:yinds[colind+1]-1], transpose(maps[mapind]), xcol, 1, 1)
@@ -265,7 +265,7 @@ function Ac_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
     # subsequent block rows, add results to corresponding parts of y
     @views for rowind in 2:length(rows)
         yinds = firstcolindices(maps[mapind+1:mapind+rows[rowind]])
-        xcol = @views x[xinds[rowind]:(xinds[rowind+1]-1)]
+        xcol = x[xinds[rowind]:(xinds[rowind+1]-1)]
         for colind in 1:rows[rowind]
             mapind +=1
             mul!(y[yinds[colind]:yinds[colind+1]-1], adjoint(maps[mapind]), xcol, 1, 1)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -172,6 +172,7 @@ function isblocksquare(A::BlockMap)
     return all(r -> r == N, rows)
 end
 
+# the following rules are sufficient but not necessary
 function LinearAlgebra.issymmetric(A::BlockMap)
     isblocksquare(A) ? N = length(A.rows) : return false
     maps = A.maps
@@ -185,7 +186,7 @@ function LinearAlgebra.issymmetric(A::BlockMap)
     end
     return true
 end
-#
+
 LinearAlgebra.ishermitian(A::BlockMap{<:Real}) = issymmetric(A)
 function LinearAlgebra.ishermitian(A::BlockMap)
     isblocksquare(A) ? N = length(A.rows) : return false

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -153,7 +153,7 @@ end
 
 promote_to_lmaps_(n::Int, dim, J::UniformScaling) = UniformScalingMap(J.λ, n)
 promote_to_lmaps_(n::Int, dim, A::LinearMap) = (check_dim(A, dim, n); A)
-promote_to_lmaps(n, k) = ()
+promote_to_lmaps(n, k, dim) = ()
 promote_to_lmaps(n, k, dim, A) = (promote_to_lmaps_(n[k], dim, A),)
 promote_to_lmaps(n, k, dim, A, B) = (promote_to_lmaps_(n[k], dim, A), promote_to_lmaps_(n[k+1], dim, B))
 promote_to_lmaps(n, k, dim, A, B, C) =

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -56,13 +56,13 @@ end
 ############
 
 for k in 1:8 # is 8 sufficient?
-      Is = ntuple(n->:($(Symbol(:A,n))::UniformScaling), Val(k-1))
-      L = :($(Symbol(:A,k))::LinearMap)
-      args = ntuple(n->Symbol(:A,n), Val(k))
+    Is = ntuple(n->:($(Symbol(:A,n))::UniformScaling), Val(k-1))
+    L = :($(Symbol(:A,k))::LinearMap)
+    args = ntuple(n->Symbol(:A,n), Val(k))
 
-      @eval Base.hcat($(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _hcat($(args...), As...)
-      @eval Base.vcat($(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _vcat($(args...), As...)
-      @eval Base.hvcat(rows::Tuple{Vararg{Int}}, $(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _hvcat(rows, $(args...), As...)
+    @eval Base.hcat($(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _hcat($(args...), As...)
+    @eval Base.vcat($(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _vcat($(args...), As...)
+    @eval Base.hvcat(rows::Tuple{Vararg{Int}}, $(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _hvcat(rows, $(args...), As...)
 end
 
 function _hcat(As::Union{LinearMap,UniformScaling}...)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -77,7 +77,7 @@ function _hcat(As::Union{LinearMap,UniformScaling}...)
             break
         end
     end
-    nrows == -1 && throw(ArgumentError("hcat of only UniformScaling objects cannot determine the matrix size"))
+    nrows == -1 && throw(ArgumentError("hcat of only UniformScaling objects cannot determine the linear map size"))
     return BlockMap{T}(promote_to_lmaps(fill(nrows, nbc), 1, 1, As...), (nbc,))
 end
 
@@ -97,7 +97,7 @@ function _vcat(As::Union{LinearMap,UniformScaling}...)
             break
         end
     end
-    ncols == -1 && throw(ArgumentError("vcat of only UniformScaling objects cannot determine the matrix size"))
+    ncols == -1 && throw(ArgumentError("vcat of only UniformScaling objects cannot determine the linear map size"))
 
     return BlockMap{T}(promote_to_lmaps(fill(ncols, nbr), 1, 2, As...), ntuple(i->1, nbr))
 end

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -28,8 +28,10 @@ Determines the respective first indices of the block rows in a virtual matrix
 representation  of the block linear map obtained from `hvcat(rows, maps...)`.
 """
 function rowindices(maps, rows)::Vector{Int}
-    firstblockindices = cumsum([1, rows[1:end-1]...,])
-    return cumsum([1, map(i -> size(maps[i], 1), firstblockindices)...,])
+    firstblockindices = vcat(1, Base.front(rows)...)
+    cumsum!(firstblockindices, firstblockindices)
+    sizes = vcat(1, map(i -> size(maps[i], 1), firstblockindices)...)
+    return cumsum!(sizes, sizes)
 end
 
 """
@@ -43,7 +45,8 @@ function columnranges(maps, rows)::Vector{UnitRange{Int}}
     colranges = Vector{UnitRange}(undef, length(maps))
     mapind = 0
     for rowind in 1:length(rows)
-        xinds = cumsum([1, map(a -> size(a, 2), maps[mapind+1:mapind+rows[rowind]])...,])
+        xinds = vcat(1, map(a -> size(a, 2), maps[mapind+1:mapind+rows[rowind]])...)
+        cumsum!(xinds, xinds)
         mapind += 1
         colranges[mapind] = xinds[1]:xinds[2]-1
         for colind in 2:rows[rowind]

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -23,11 +23,11 @@ sumshift(a::Tuple{Vararg{Int}}, b::Tuple{Int}) = tuple(a..., last(a) + first(b))
 function firstrowindices(A::BlockMap)
     as, rows = A.maps, A.rows
 
-	firstrows = sumshift(A.rows)
-	Afirstcol = ntuple(length(firstrows)-1) do i
-		A.maps[firstrows[i]]
-	end
-	return sumshift(map(a -> size(a, 1), Afirstcol))
+    firstrows = sumshift(A.rows)
+    Afirstcol = ntuple(length(firstrows)-1) do i
+        A.maps[firstrows[i]]
+    end
+    return sumshift(map(a -> size(a, 1), Afirstcol))
 end
 
 @inline firstcolindices(As::Tuple{Vararg{LinearMap}}) = sumshift(map(a -> size(a, 2), As))

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -38,8 +38,8 @@ At_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector) = A_mul_B!
 Ac_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector) = A_mul_B!(y, adjoint(A), x)
 
 function LinearAlgebra.mul!(y::AbstractVector, J::UniformScalingMap{T}, x::AbstractVector, α::Number=one(T), β::Number=zero(T)) where {T}
-    length(y) == size(J, 1) || throw(DimensionMismatch("mul!"))
-    if isone(α)
+    @boundscheck (length(x) == length(y) == J.M || throw(DimensionMismatch("mul!")))
+    @inbounds if isone(α)
         if iszero(β)
             A_mul_B!(y, J, x)
             return y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -540,10 +540,12 @@ end
             @test Matrix([LB; LA LA LA]) ≈ [B; A A A]
             @test [I; LA LA LA] isa LinearMaps.BlockMap{elty}
             @test Matrix([I; LA LA LA]) ≈ [I; A A A]
-            A12 = rand(elty, 10, 21)
-            A21 = rand(elty, 20, 10)
-            @test_throws ArgumentError A = [I A12; A21 I]
-            @test_throws ArgumentError A = [A12 A12; A21 A21]
+            A12 = LinearMap(rand(elty, 10, 21))
+            A21 = LinearMap(rand(elty, 20, 10))
+            @test_throws DimensionMismatch A = [I A12; A21 I]
+            @test_throws DimensionMismatch A = [I A21; A12 I]
+            @test_throws DimensionMismatch A = [A12 A12; A21 A21]
+            @test_throws DimensionMismatch A = [A12 A21; A12 A21]
         end
     end
     @testset "adjoint/transpose" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -406,6 +406,12 @@ end
         @inferred mul!(y, Λ, x, α, β)
         @test y ≈ λ * x * α + β * x
     end
+    for elty in (Float64, ComplexF64), transform in (transpose, adjoint)
+        λ = rand(elty)
+        x = rand(10)
+        J = @inferred LinearMap(LinearMaps.UniformScalingMap(λ, 10))
+        @test transform(J) * x == transform(λ) * x
+    end
 end
 
 @testset "noncommutative number type" begin
@@ -512,6 +518,8 @@ end
             A = [A11 A12; A21 A22]
             @inferred hvcat((2,2), LinearMap(A11), LinearMap(A12), LinearMap(A21), LinearMap(A22))
             L = [LinearMap(A11) LinearMap(A12); LinearMap(A21) LinearMap(A22)]
+            @test @inferred !issymmetric(L)
+            @test @inferred !ishermitian(L)
             x = rand(30)
             @test L isa LinearMaps.BlockMap{elty}
             @test size(L) == size(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,14 +545,14 @@ end
             L = [I LinearMap(A12); transform(LinearMap(A12)) I]
             if elty <: Complex
                 if transform == transpose
-                    @test issymmetric(L)
+                    @test @inferred issymmetric(L)
                 else
-                    @test ishermitian(L)
+                    @test @inferred ishermitian(L)
                 end
             end
             if elty <: Real
-                @test ishermitian(L)
-                @test issymmetric(L)
+                @test @inferred ishermitian(L)
+                @test @inferred issymmetric(L)
             end
             x = rand(elty, 20)
             @test L isa LinearMaps.LinearMap{elty}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,7 +194,7 @@ end
     @test mul!(u, L, v) ≈ n * cumsum(v)
     b = @benchmarkable mul!($u, $L, $v)
     @test run(b, samples=5).allocs <= 1
-    
+
     A = 2 * rand(ComplexF64, (10, 10)) .- 1
     B = rand(size(A)...)
     M = @inferred LinearMap(A)
@@ -543,7 +543,17 @@ end
             A12 = rand(elty, 10, 10)
             A = [I A12; transform(A12) I]
             L = [I LinearMap(A12); transform(LinearMap(A12)) I]
-            @test_broken ishermitian(L)
+            if elty <: Complex
+                if transform == transpose
+                    @test issymmetric(L)
+                else
+                    @test ishermitian(L)
+                end
+            end
+            if elty <: Real
+                @test ishermitian(L)
+                @test issymmetric(L)
+            end
             x = rand(elty, 20)
             @test L isa LinearMaps.LinearMap{elty}
             @test size(L) == size(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ AV = A * V
     @test M * v == Av
     @test N * v == Av
     @test @inferred mul!(copy(w), M, v) == mul!(copy(w), A, v)
-    b = @benchmarkable mul!(w, M, v)
+    b = @benchmarkable mul!($w, $M, $v)
     @test run(b, samples=3).allocs == 0
     @test @inferred mul!(copy(w), N, v) == Av
 
@@ -183,27 +183,27 @@ end
     @test @inferred transpose(2 * L) * v ≈ 2 * v
 end
 
-CS! = @inferred LinearMap(cumsum!, 10; ismutating=true)
-v = rand(10)
-u = similar(v)
-b = @benchmarkable mul!(u, CS!, v)
-@test run(b, samples=3).allocs == 0
-n = 10
-L = sum(fill(CS!, n))
-@test mul!(u, L, v) ≈ n * cumsum(v)
-b = @benchmarkable mul!(u, L, v)
-@test run(b, samples=5).allocs <= 1
-
-A = 2 * rand(ComplexF64, (10, 10)) .- 1
-B = rand(size(A)...)
-M = @inferred LinearMap(A)
-N = @inferred LinearMap(B)
-LC = @inferred M + N
-v = rand(ComplexF64, 10)
-w = similar(v)
-b = @benchmarkable mul!(w, M, v)
-@test run(b, samples=3).allocs == 0
 @testset "linear combinations" begin
+    CS! = @inferred LinearMap(cumsum!, 10; ismutating=true)
+    v = rand(10)
+    u = similar(v)
+    b = @benchmarkable mul!($u, $CS!, $v)
+    @test run(b, samples=3).allocs == 0
+    n = 10
+    L = sum(fill(CS!, n))
+    @test mul!(u, L, v) ≈ n * cumsum(v)
+    b = @benchmarkable mul!($u, $L, $v)
+    @test run(b, samples=5).allocs <= 1
+    
+    A = 2 * rand(ComplexF64, (10, 10)) .- 1
+    B = rand(size(A)...)
+    M = @inferred LinearMap(A)
+    N = @inferred LinearMap(B)
+    LC = @inferred M + N
+    v = rand(ComplexF64, 10)
+    w = similar(v)
+    b = @benchmarkable mul!($w, $M, $v)
+    @test run(b, samples=3).allocs == 0
     # @test_throws ErrorException LinearMaps.LinearCombination{ComplexF64}((M, N), (1, 2, 3))
     @test @inferred size(3M + 2.0N) == size(A)
     # addition
@@ -357,14 +357,14 @@ mul!(y::Vector, A::Union{SimpleFunctionMap,SimpleComplexFunctionMap}, x::Vector)
     end
 end
 
-A = rand(10, 20)
-B = rand(ComplexF64, 10, 20)
-SA = A'A + I
-SB = B'B + I
-L = @inferred LinearMap{Float64}(A)
-MA = @inferred LinearMap(SA)
-MB = @inferred LinearMap(SB)
 @testset "wrapped maps" begin
+    A = rand(10, 20)
+    B = rand(ComplexF64, 10, 20)
+    SA = A'A + I
+    SB = B'B + I
+    L = @inferred LinearMap{Float64}(A)
+    MA = @inferred LinearMap(SA)
+    MB = @inferred LinearMap(SB)
     @test size(L) == size(A)
     @test @inferred !issymmetric(L)
     @test @inferred issymmetric(MA)
@@ -373,14 +373,14 @@ MB = @inferred LinearMap(SB)
     @test @inferred isposdef(MB)
 end
 
-A = 2 * rand(ComplexF64, (10, 10)) .- 1
-B = rand(size(A)...)
-M = @inferred 1 * LinearMap(A)
-N = @inferred LinearMap(B)
-LC = @inferred M + N
-v = rand(ComplexF64, 10)
-w = similar(v)
 @testset "identity/scaling map" begin
+    A = 2 * rand(ComplexF64, (10, 10)) .- 1
+    B = rand(size(A)...)
+    M = @inferred 1 * LinearMap(A)
+    N = @inferred LinearMap(B)
+    LC = @inferred M + N
+    v = rand(ComplexF64, 10)
+    w = similar(v)
     Id = @inferred LinearMaps.UniformScalingMap(1, 10)
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, 10, 20)
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, (10, 20))
@@ -396,6 +396,16 @@ w = similar(v)
     @test (3 * I - 2 * M') * v == -2 * A'v + 3v
     @test transpose(LinearMap(2 * M' + 3 * I)) * v ≈ transpose(2 * A' + 3 * I) * v
     @test LinearMap(2 * M' + 3 * I)' * v ≈ (2 * A' + 3 * I)' * v
+    for λ in (0, 1, rand()), α in (0, 1, rand()), β in (0, 1, rand())
+        Λ = @inferred LinearMaps.UniformScalingMap(λ, 10)
+        x = rand(10)
+        y = rand(10)
+        b = @benchmarkable mul!($y, $Λ, $x, $α, $β)
+        @test run(b, samples=3).allocs == 0
+        y = deepcopy(x)
+        @inferred mul!(y, Λ, x, α, β)
+        @test y ≈ λ * x * α + β * x
+    end
 end
 
 @testset "noncommutative number type" begin


### PR DESCRIPTION
I couldn't stop myself from further optimizing things, partly for my own education (@JeffFessler 😉 ). Let me start with a simple "benchmark problem".
```julia
using LinearMaps, LinearAlgebra, BenchmarkTools
A = LinearMap(rand(10, 10))
L = hvcat((2, 2), A, A, A, I)
x = rand(size(L, 2))
y = rand(size(L, 1))
@btime mul!($y, $L, $x)
M = Matrix(L)
@btime mul!($y, $M, $x)
```
On current master, we get:
```julia
 2.682 μs (33 allocations: 2.23 KiB)
  97.825 ns (0 allocations: 0 bytes)
```
On this branch, we get:
```julia
 1.365 μs (17 allocations: 896 bytes)
  96.926 ns (0 allocations: 0 bytes)
```
So, a factor of 2 on this small problem. What has happened? I changed from the `Vector`-based `cumsum` formulation of obtaining the starting indices corresponding to blocks, and changed it to a tuple-based, recursive, inferable formulation. Obviously, the values obtained are the exact same in all cases. This is responsible for the major improvement above. This is compiler magic that I haven't expected myself.

What else? We are allocating memory because we generally can't compute the target vectors component-wise. So when we add the result of some block multiplication to a previous result, we need to first allocate the intermediate result before we can add it. This is, in general, unavoidable. BUT, there are two exceptions: uniform scalings (for which I have an allocation-free (this is tested!), 5-arg `mul!`), and wrapped maps with BLAS-matrices. Unfortunately, we don't have that 5-arg mul! for (dense) matrices, yet. But the minute that is coming, our code will perform better immediately. The remaining allocations are likely to generate views. For instance
```julia
L = [A I I]
x = rand(size(L, 2))
y = rand(size(L, 1))
@btime mul!($y, $L, $x)
```
should not be allocating at all, because the identities are handled by the allocation-free 5-arg `mul!`, but we still get
```julia
 687.351 ns (14 allocations: 624 bytes)
```
in comparison to
```julia
M = Matrix(L)
@btime mul!($y, $M, $x)
133.692 ns (0 allocations: 0 bytes)
```
In good cases, I think the overhead is pretty much constant, and is likely to be irrelevant when costly matrix multiplication is involved.

Other minor improvements include that size checks are now done at linear map promotion.