### PR TITLE
miscellaneous updates

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -27,7 +27,7 @@ Base.size(A::LinearMap, n) = (n==1 || n==2 ? size(A)[n] : error("LinearMap objec
 Base.length(A::LinearMap) = size(A)[1] * size(A)[2]
 
 Base.:(*)(A::LinearMap, x::AbstractVector) = mul!(similar(x, promote_type(eltype(A), eltype(x)), size(A, 1)), A, x)
-function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap{T}, x::AbstractVector, α::Number=one(T), β::Number=zero(T)) where {T}
+function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap, x::AbstractVector, α::Number=true, β::Number=false)
     length(y) == size(A, 1) || throw(DimensionMismatch("mul!"))
     if α == 1
         β == 0 && (A_mul_B!(y, A, x); return y)
@@ -52,7 +52,7 @@ function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap{T}, x::AbstractVecto
     end
 end
 # the following is of interest in, e.g., subspace-iteration methods
-function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap{T}, X::AbstractMatrix, α::Number=one(T), β::Number=zero(T)) where {T}
+function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix, α::Number=true, β::Number=false)
     (size(Y, 1) == size(A, 1) && size(X, 1) == size(A, 2) && size(Y, 2) == size(X, 2)) || throw(DimensionMismatch("mul!"))
     @inbounds @views for i = 1:size(X, 2)
         mul!(Y[:, i], A, X[:, i], α, β)

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -64,9 +64,9 @@ function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix, 
     return Y
 end
 
-A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
-At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
-Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
+@inline A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
+@inline At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
+@inline Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
 
 # Matrix: create matrix representation of LinearMap
 function Base.Matrix(A::LinearMap)

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -5,6 +5,13 @@ export LinearMap
 using LinearAlgebra
 using SparseArrays
 
+if VERSION < v"1.2-"
+    import Base: has_offset_axes
+    require_one_based_indexing(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+else
+    import Base: require_one_based_indexing
+end
+
 abstract type LinearMap{T} end
 
 Base.eltype(::LinearMap{T}) where {T} = T

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -64,9 +64,9 @@ function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix, 
     return Y
 end
 
-@inline A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
-@inline At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
-@inline Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
+A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
+At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
+Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
 
 # Matrix: create matrix representation of LinearMap
 function Base.Matrix(A::LinearMap)

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -29,22 +29,22 @@ Base.length(A::LinearMap) = size(A)[1] * size(A)[2]
 Base.:(*)(A::LinearMap, x::AbstractVector) = mul!(similar(x, promote_type(eltype(A), eltype(x)), size(A, 1)), A, x)
 function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap, x::AbstractVector, α::Number=true, β::Number=false)
     length(y) == size(A, 1) || throw(DimensionMismatch("mul!"))
-    if α == 1
-        β == 0 && (A_mul_B!(y, A, x); return y)
-        β == 1 && (y .+= A * x; return y)
+    if isone(α)
+        iszero(β) && (A_mul_B!(y, A, x); return y)
+        isone(β) && (y .+= A * x; return y)
         # β != 0, 1
         rmul!(y, β)
         y .+= A * x
         return y
-    elseif α == 0
-        β == 0 && (fill!(y, zero(eltype(y))); return y)
-        β == 1 && return y
+    elseif iszero(α)
+        iszero(β) && (fill!(y, zero(eltype(y))); return y)
+        isone(β) && return y
         # β != 0, 1
         rmul!(y, β)
         return y
     else # α != 0, 1
-        β == 0 && (A_mul_B!(y, A, x); rmul!(y, α); return y)
-        β == 1 && (y .+= rmul!(A * x, α); return y)
+        iszero(β) && (A_mul_B!(y, A, x); rmul!(y, α); return y)
+        isone(β) && (y .+= rmul!(A * x, α); return y)
         # β != 0, 1
         rmul!(y, β)
         y .+= rmul!(A * x, α)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -50,7 +50,7 @@ end
 Base.size(A::BlockMap) = (last(A.rowranges[end]), last(A.colranges[end]))
 
 ############
-# hcat
+# concatenation
 ############
 
 for k in 1:8 # is 8 sufficient?
@@ -62,6 +62,32 @@ for k in 1:8 # is 8 sufficient?
     @eval Base.vcat($(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _vcat($(args...), As...)
     @eval Base.hvcat(rows::Tuple{Vararg{Int}}, $(Is...), $L, As::Union{LinearMap,UniformScaling}...) = _hvcat(rows, $(args...), As...)
 end
+
+############
+# hcat
+############
+"""
+    hcat(As::Union{LinearMap,UniformScaling}...)
+
+Construct a `BlockMap <: LinearMap` object, a (lazy) representation of the
+horizontal concatenation of the arguments. `UniformScaling` objects are promoted
+to `LinearMap` automatically. To avoid fallback to the generic [`Base.hcat`](@ref),
+there must be a `LinearMap` object among the first 8 arguments.
+
+# Examples
+```jldoctest; setup=(using LinearMaps)
+julia> CS = LinearMap{Int}(cumsum, 3)::LinearMaps.FunctionMap;
+
+julia> L = [CS LinearMap(ones(Int, 3, 3))]::LinearMaps.BlockMap;
+
+julia> L * ones(Int, 6)
+3-element Array{Int64,1}:
+ 4
+ 5
+ 6
+```
+"""
+Base.hcat
 
 function _hcat(As::Union{LinearMap,UniformScaling}...)
     T = promote_type(map(eltype, As)...)
@@ -82,6 +108,31 @@ end
 ############
 # vcat
 ############
+"""
+    vcat(As::Union{LinearMap,UniformScaling}...)
+
+Construct a `BlockMap <: LinearMap` object, a (lazy) representation of the
+vertical concatenation of the arguments. `UniformScaling` objects are promoted
+to `LinearMap` automatically. To avoid fallback to the generic [`Base.vcat`](@ref),
+there must be a `LinearMap` object among the first 8 arguments.
+
+# Examples
+```jldoctest; setup=(using LinearMaps)
+julia> CS = LinearMap{Int}(cumsum, 3)::LinearMaps.FunctionMap;
+
+julia> L = [CS; LinearMap(ones(Int, 3, 3))]::LinearMaps.BlockMap;
+
+julia> L * ones(Int, 3)
+6-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 3
+ 3
+ 3
+```
+"""
+Base.vcat
 
 function _vcat(As::Union{LinearMap,UniformScaling}...)
     T = promote_type(map(eltype, As)...)
@@ -103,6 +154,35 @@ end
 ############
 # hvcat
 ############
+"""
+    hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling}...)
+
+Construct a `BlockMap <: LinearMap` object, a (lazy) representation of the
+horizontal-vertical concatenation of the arguments. The first argument specifies
+the number of arguments to concatenate in each block row. `UniformScaling` objects
+are promoted to `LinearMap` automatically. To avoid fallback to the generic
+[`Base.hvcat`](@ref), there must be a `LinearMap` object among the first 8 arguments.
+
+# Examples
+```jldoctest; setup=(using LinearMaps)
+julia> CS = LinearMap{Int}(cumsum, 3)::LinearMaps.FunctionMap;
+
+julia> L = [CS CS; CS CS]::LinearMaps.BlockMap;
+
+julia> L.rows
+(2, 2)
+
+julia> L * ones(Int, 6)
+6-element Array{Int64,1}:
+ 2
+ 4
+ 6
+ 2
+ 4
+ 6
+```
+"""
+Base.hvcat
 
 function _hvcat(rows::Tuple{Vararg{Int}}, As::Union{LinearMap,UniformScaling}...)
     nr = length(rows)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -221,6 +221,7 @@ LinearAlgebra.adjoint(A::BlockMap)  = AdjointMap(A)
 ############
 
 function A_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+    require_one_based_indexing(y, x)
     m, n = size(A)
     @boundscheck (m == length(y) && n == length(x)) || throw(DimensionMismatch("A_mul_B!"))
     maps, rows, yinds, xinds = A.maps, A.rows, A.rowranges, A.colranges
@@ -238,6 +239,7 @@ function A_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
 end
 
 function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+    require_one_based_indexing(y, x)
     m, n = size(A)
     @boundscheck (n == length(y) && m == length(x)) || throw(DimensionMismatch("At_mul_B!"))
     maps, rows, xinds, yinds = A.maps, A.rows, A.rowranges, A.colranges
@@ -262,6 +264,7 @@ function At_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
 end
 
 function Ac_mul_B!(y::AbstractVector, A::BlockMap, x::AbstractVector)
+    require_one_based_indexing(y, x)
     m, n = size(A)
     @boundscheck (n == length(y) && m == length(x)) || throw(DimensionMismatch("At_mul_B!"))
     maps, rows, xinds, yinds = A.maps, A.rows, A.rowranges, A.colranges

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -14,6 +14,7 @@ end
 CompositeMap{T}(maps::As) where {T, As<:Tuple{Vararg{LinearMap}}} = CompositeMap{T, As}(maps)
 
 # basic methods
+Base.size(A::CompositeMap, n) = n==1 ? size(A.maps[end], 1) : n==2 ? size(A.maps[1], 2) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::CompositeMap) = (size(A.maps[end], 1), size(A.maps[1], 2))
 Base.isreal(A::CompositeMap) = all(isreal, A.maps) # sufficient but not necessary
 

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -14,7 +14,6 @@ end
 CompositeMap{T}(maps::As) where {T, As<:Tuple{Vararg{LinearMap}}} = CompositeMap{T, As}(maps)
 
 # basic methods
-Base.size(A::CompositeMap, n) = n==1 ? size(A.maps[end], 1) : n==2 ? size(A.maps[1], 2) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::CompositeMap) = (size(A.maps[end], 1), size(A.maps[1], 2))
 Base.isreal(A::CompositeMap) = all(isreal, A.maps) # sufficient but not necessary
 

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -30,7 +30,6 @@ function Base.show(io::IO, A::FunctionMap{T}) where {T}
 end
 
 # properties
-Base.size(A::FunctionMap, n) = n==1 ? A.M : n==2 ? A.N : error("LinearMap objects have only 2 dimensions")
 Base.size(A::FunctionMap) = (A.M, A.N)
 LinearAlgebra.issymmetric(A::FunctionMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::FunctionMap) = A._ishermitian

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -39,7 +39,7 @@ _ismutating(f) = first(methods(f)).nargs == 3
 
 # special transposition behavior
 function LinearAlgebra.transpose(A::FunctionMap)
-    if A.fc!==nothing || A._issymmetric
+    if A._issymmetric || (eltype(A) <: Real && A.fc !== nothing)
         return TransposeMap(A)
     else
         error("transpose not implemented for $A")

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -46,6 +46,7 @@ function LinearAlgebra.transpose(A::FunctionMap)
         error("transpose not implemented for $A")
     end
 end
+LinearAlgebra.adjoint(A::FunctionMap{<:Real}) = transpose(A)
 function LinearAlgebra.adjoint(A::FunctionMap)
     if A.fc!==nothing || A._ishermitian
         return AdjointMap(A)

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -37,23 +37,6 @@ LinearAlgebra.isposdef(A::FunctionMap)    = A._isposdef
 ismutating(A::FunctionMap) = A._ismutating
 _ismutating(f) = first(methods(f)).nargs == 3
 
-# special transposition behavior
-function LinearAlgebra.transpose(A::FunctionMap)
-    if A._issymmetric || (eltype(A) <: Real && A.fc !== nothing)
-        return TransposeMap(A)
-    else
-        error("transpose not implemented for $A")
-    end
-end
-LinearAlgebra.adjoint(A::FunctionMap{<:Real}) = transpose(A)
-function LinearAlgebra.adjoint(A::FunctionMap)
-    if A.fc!==nothing || A._ishermitian
-        return AdjointMap(A)
-    else
-        error("adjoint not implemented for $A")
-    end
-end
-
 # multiplication with vector
 function Base.:(*)(A::FunctionMap, x::AbstractVector)
     length(x) == A.N || throw(DimensionMismatch())

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -36,7 +36,7 @@ LinearAlgebra.issymmetric(A::FunctionMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::FunctionMap) = A._ishermitian
 LinearAlgebra.isposdef(A::FunctionMap)    = A._isposdef
 ismutating(A::FunctionMap) = A._ismutating
-_ismutating(f) = (mf = methods(f); !isempty(mf) ? first(methods(f)).nargs == 3 : error("transpose/adjoint not implemented"))
+_ismutating(f) = first(methods(f)).nargs == 3
 
 # special transposition behavior
 function LinearAlgebra.transpose(A::FunctionMap)

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -21,10 +21,26 @@ LinearAlgebra.ishermitian(A::LinearCombination) = all(ishermitian, A.maps) # suf
 LinearAlgebra.isposdef(A::LinearCombination) = all(isposdef, A.maps) # sufficient but not necessary
 
 # adding linear maps
-function Base.:(+)(A₁::LinearCombination, A₂::LinearCombination)
+"""
+    A::LinearMap + B::LinearMap
+
+Construct a `LinearCombination <: LinearMap`, a (lazy) representation of the sum
+of the two operators. Sums of `LinearMap`/`LinearCombination` objects and
+`LinearMap`/`LinearCombination` objects are reduced to a single `LinearCombination`.
+In sums of `LinearMap`s and `AbstractMatrix`/`UniformScaling` objects, the latter
+get promoted to `LinearMap`s automatically.
+
+# Examples
+```jldoctest; setup=(using LinearAlgebra, LinearMaps)
+julia> CS = LinearMap{Int}(cumsum, 3)::LinearMaps.FunctionMap;
+
+julia> LinearMap(ones(Int, 3, 3)) + CS + I + rand(3, 3);
+```
+"""
+function Base.:(+)(A₁::LinearMap, A₂::LinearMap)
     size(A₁) == size(A₂) || throw(DimensionMismatch("+"))
     T = promote_type(eltype(A₁), eltype(A₂))
-    return LinearCombination{T}(tuple(A₁.maps..., A₂.maps...))
+    return LinearCombination{T}(tuple(A₁, A₂))
 end
 function Base.:(+)(A₁::LinearMap, A₂::LinearCombination)
     size(A₁) == size(A₂) || throw(DimensionMismatch("+"))
@@ -32,10 +48,10 @@ function Base.:(+)(A₁::LinearMap, A₂::LinearCombination)
     return LinearCombination{T}(tuple(A₁, A₂.maps...))
 end
 Base.:(+)(A₁::LinearCombination, A₂::LinearMap) = +(A₂, A₁)
-function Base.:(+)(A₁::LinearMap, A₂::LinearMap)
+function Base.:(+)(A₁::LinearCombination, A₂::LinearCombination)
     size(A₁) == size(A₂) || throw(DimensionMismatch("+"))
     T = promote_type(eltype(A₁), eltype(A₂))
-    return LinearCombination{T}(tuple(A₁, A₂))
+    return LinearCombination{T}(tuple(A₁.maps..., A₂.maps...))
 end
 Base.:(-)(A₁::LinearMap, A₂::LinearMap) = +(A₁, -A₂)
 

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -14,7 +14,6 @@ end
 LinearCombination{T}(maps::As) where {T, As} = LinearCombination{T, As}(maps)
 
 # basic methods
-Base.size(A::LinearCombination, n) = n==1 ? size(A.maps[1], 1) : n==2 ? size(A.maps[1], 2) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::LinearCombination) = size(A.maps[1])
 LinearAlgebra.issymmetric(A::LinearCombination) = all(issymmetric, A.maps) # sufficient but not necessary
 LinearAlgebra.ishermitian(A::LinearCombination) = all(ishermitian, A.maps) # sufficient but not necessary

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -14,6 +14,7 @@ end
 LinearCombination{T}(maps::As) where {T, As} = LinearCombination{T, As}(maps)
 
 # basic methods
+Base.size(A::LinearCombination, n) = n==1 ? size(A.maps[1], 1) : n==2 ? size(A.maps[1], 2) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::LinearCombination) = size(A.maps[1])
 LinearAlgebra.issymmetric(A::LinearCombination) = all(issymmetric, A.maps) # sufficient but not necessary
 LinearAlgebra.ishermitian(A::LinearCombination) = all(ishermitian, A.maps) # sufficient but not necessary

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -15,7 +15,7 @@ LinearAlgebra.adjoint(A::LinearMap) = AdjointMap(A)
 
 # properties
 Base.size(A::Union{TransposeMap, AdjointMap}, n) = n==1 ? size(A.lmap, 2) : n==2 ? size(A.lmap, 1) : error("LinearMap objects have only 2 dimensions")
-Base.size(A::Union{TransposeMap, AdjointMap}) = (size(A.lmap, 2), size(A.lmap, 1))
+Base.size(A::Union{TransposeMap, AdjointMap}) = reverse(size(A.lmap))
 LinearAlgebra.issymmetric(A::Union{TransposeMap, AdjointMap}) = issymmetric(A.lmap)
 LinearAlgebra.ishermitian(A::Union{TransposeMap, AdjointMap}) = ishermitian(A.lmap)
 LinearAlgebra.isposdef(A::Union{TransposeMap, AdjointMap}) = isposdef(A.lmap)

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -14,7 +14,6 @@ LinearAlgebra.adjoint(A::LinearMap{<:Real}) = transpose(A)
 LinearAlgebra.adjoint(A::LinearMap) = AdjointMap(A)
 
 # properties
-Base.size(A::Union{TransposeMap, AdjointMap}, n) = n==1 ? size(A.lmap, 2) : n==2 ? size(A.lmap, 1) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::Union{TransposeMap, AdjointMap}) = reverse(size(A.lmap))
 LinearAlgebra.issymmetric(A::Union{TransposeMap, AdjointMap}) = issymmetric(A.lmap)
 LinearAlgebra.ishermitian(A::Union{TransposeMap, AdjointMap}) = ishermitian(A.lmap)

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -14,6 +14,7 @@ LinearAlgebra.adjoint(A::LinearMap{<:Real}) = transpose(A)
 LinearAlgebra.adjoint(A::LinearMap) = AdjointMap(A)
 
 # properties
+Base.size(A::Union{TransposeMap, AdjointMap}, n) = n==1 ? size(A.lmap, 2) : n==2 ? size(A.lmap, 1) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::Union{TransposeMap, AdjointMap}) = (size(A.lmap, 2), size(A.lmap, 1))
 LinearAlgebra.issymmetric(A::Union{TransposeMap, AdjointMap}) = issymmetric(A.lmap)
 LinearAlgebra.ishermitian(A::Union{TransposeMap, AdjointMap}) = ishermitian(A.lmap)

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -8,6 +8,7 @@ UniformScalingMap(λ::T, sz::Tuple{Int, Int}) where {T} =
     (sz[1] == sz[2] ? UniformScalingMap(λ, sz[1]) : error("UniformScalingMap needs to be square"))
 
 # properties
+Base.size(A::UniformScalingMap, n) = n in (1, 2) ? A.M : error("LinearMap objects have only 2 dimensions")
 Base.size(A::UniformScalingMap) = (A.M, A.M)
 Base.isreal(A::UniformScalingMap) = isreal(A.λ)
 LinearAlgebra.issymmetric(::UniformScalingMap) = true

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -1,6 +1,10 @@
 struct UniformScalingMap{T} <: LinearMap{T}
     λ::T
     M::Int
+    function UniformScalingMap(λ::T, M::Int) where {T}
+        M ≤ 0 && throw(ArgumentError("size of UniformScalingMap must be (strictly) positive, got $M"))
+        return new{T}(λ, M)
+    end
 end
 UniformScalingMap(λ::T, M::Int, N::Int) where {T} =
     (M == N ? UniformScalingMap(λ, M) : error("UniformScalingMap needs to be square"))

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -12,7 +12,6 @@ UniformScalingMap(λ::Number, sz::Tuple{Int, Int}) =
     (sz[1] == sz[2] ? UniformScalingMap(λ, sz[1]) : error("UniformScalingMap needs to be square"))
 
 # properties
-Base.size(A::UniformScalingMap, n) = n in (1, 2) ? A.M : error("LinearMap objects have only 2 dimensions")
 Base.size(A::UniformScalingMap) = (A.M, A.M)
 Base.isreal(A::UniformScalingMap) = isreal(A.λ)
 LinearAlgebra.issymmetric(::UniformScalingMap) = true

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -50,7 +50,7 @@ function A_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector)
 end
 end # VERSION
 
-function LinearAlgebra.mul!(y::AbstractVector, J::UniformScalingMap{T}, x::AbstractVector, α::Number=one(T), β::Number=zero(T)) where {T}
+function LinearAlgebra.mul!(y::AbstractVector, J::UniformScalingMap, x::AbstractVector, α::Number=true, β::Number=false)
     @boundscheck (length(x) == length(y) == J.M || throw(DimensionMismatch("mul!")))
     λ = J.λ
     @inbounds if isone(α)

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -1,14 +1,14 @@
 struct UniformScalingMap{T} <: LinearMap{T}
     λ::T
     M::Int
-    function UniformScalingMap(λ::T, M::Int) where {T}
+    function UniformScalingMap(λ::Number, M::Int)
         M ≤ 0 && throw(ArgumentError("size of UniformScalingMap must be (strictly) positive, got $M"))
-        return new{T}(λ, M)
+        return new{typeof(λ)}(λ, M)
     end
 end
-UniformScalingMap(λ::T, M::Int, N::Int) where {T} =
+UniformScalingMap(λ::Number, M::Int, N::Int) =
     (M == N ? UniformScalingMap(λ, M) : error("UniformScalingMap needs to be square"))
-UniformScalingMap(λ::T, sz::Tuple{Int, Int}) where {T} =
+UniformScalingMap(λ::Number, sz::Tuple{Int, Int}) =
     (sz[1] == sz[2] ? UniformScalingMap(λ, sz[1]) : error("UniformScalingMap needs to be square"))
 
 # properties

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -2,7 +2,7 @@ struct UniformScalingMap{T} <: LinearMap{T}
     λ::T
     M::Int
     function UniformScalingMap(λ::Number, M::Int)
-        M ≤ 0 && throw(ArgumentError("size of UniformScalingMap must be (strictly) positive, got $M"))
+        M < 0 && throw(ArgumentError("size of UniformScalingMap must be non-negative, got $M"))
         return new{typeof(λ)}(λ, M)
     end
 end

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -36,6 +36,7 @@ LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector, α::Numb
 end # VERSION
 
 # properties
+Base.size(A::WrappedMap, n) = n in (1, 2) ? size(A.lmap, n) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::WrappedMap) = size(A.lmap)
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -36,7 +36,6 @@ LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector, α::Numb
 end # VERSION
 
 # properties
-Base.size(A::WrappedMap, n) = n in (1, 2) ? size(A.lmap, n) : error("LinearMap objects have only 2 dimensions")
 Base.size(A::WrappedMap) = size(A.lmap)
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -15,6 +15,7 @@ LinearAlgebra.mul!(y::Vector, A::Union{SimpleFunctionMap,SimpleComplexFunctionMa
 
 @testset "composition" begin
     F = @inferred LinearMap(cumsum, y -> reverse(cumsum(reverse(x))), 10; ismutating=false)
+    FC = @inferred LinearMap{ComplexF64}(cumsum, y -> reverse(cumsum(reverse(x))), 10; ismutating=false)
     A = 2 * rand(ComplexF64, (10, 10)) .- 1
     B = rand(size(A)...)
     M = @inferred 1 * LinearMap(A)
@@ -32,6 +33,10 @@ LinearAlgebra.mul!(y::Vector, A::Union{SimpleFunctionMap,SimpleComplexFunctionMa
     @test @inferred ishermitian(N * N')
     @test @inferred !issymmetric(M' * M)
     @test @inferred ishermitian(M' * M)
+    @test @inferred issymmetric(F'F)
+    @test @inferred ishermitian(F'F)
+    @test @inferred !issymmetric(FC'FC)
+    @test @inferred ishermitian(FC'FC)
     @test @inferred isposdef(transpose(F) * F * 3)
     @test @inferred isposdef(transpose(F) * 3 * F)
     @test @inferred !isposdef(-5*transpose(F) * F)

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -58,7 +58,6 @@ using Test, LinearMaps, LinearAlgebra
     @test_throws ErrorException adjoint(CS!) * v
     CS! = LinearMap{ComplexF64}(cumsum!, (y, x) -> (copyto!(y, x); reverse!(y); cumsum!(y, y)), 10; ismutating=true)
     @inferred adjoint(CS!)
-    @inferred transpose(CS!)
     @test @inferred LinearMaps.ismutating(CS!)
     @test @inferred CS! * v == cv
     @test @inferred *(CS!, v) == cv

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -57,6 +57,8 @@ using Test, LinearMaps, LinearAlgebra
     @test_throws ErrorException CS!'v
     @test_throws ErrorException adjoint(CS!) * v
     CS! = LinearMap{ComplexF64}(cumsum!, (y, x) -> (copyto!(y, x); reverse!(y); cumsum!(y, y)), 10; ismutating=true)
+    @inferred adjoint(CS!)
+    @inferred transpose(CS!)
     @test @inferred LinearMaps.ismutating(CS!)
     @test @inferred CS! * v == cv
     @test @inferred *(CS!, v) == cv

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -1,6 +1,7 @@
 using Test, LinearMaps, LinearAlgebra, BenchmarkTools
 
 @testset "identity/scaling map" begin
+    @test_throws ArgumentError LinearMaps.UniformScalingMap(true, 0)
     A = 2 * rand(ComplexF64, (10, 10)) .- 1
     B = rand(size(A)...)
     M = @inferred 1 * LinearMap(A)

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -1,7 +1,7 @@
 using Test, LinearMaps, LinearAlgebra, BenchmarkTools
 
 @testset "identity/scaling map" begin
-    @test_throws ArgumentError LinearMaps.UniformScalingMap(true, 0)
+    @test_throws ArgumentError LinearMaps.UniformScalingMap(true, -1)
     A = 2 * rand(ComplexF64, (10, 10)) .- 1
     B = rand(size(A)...)
     M = @inferred 1 * LinearMap(A)


### PR DESCRIPTION
* ~~add size(A, i)
  I realized we more often use `size(A, i)` instead of `size(A)`, and the interface requests to have `size(A)`, and `size(A, i)` computes by default `size(A)[i]`. As for the API, I think this is fine, but I felt we should have specialized methods for individual sizes whenever possible to save unnecessary computations. In all cases that effort is trivial compared to others, but still in some cases there is a little work to be done.~~
* ~~make FunctionMap adjoint/transpose-invariant
  We were handling adjoints/transposes of `FunctionMaps` a bit loose. We never checked at construction whether the adjoint is defined, and we never checked whether the adjoint is also in-place. ~~Since all information is available, I thought we may as well construct a new `FunctionMap`, and at that point guess again whether `fc` is also in-place or not. Also, this saves us one hierarchical level.~~ EDIT: That doesn't work well. Instead, I added some test. Strictly speaking, we still can define a `FunctionMap` where `f` is in-place, and `fc` isn't. This is still not caught a priori, but will yield an error at multiplication.~~
* require one-based indexing in multiplications that index into the vectors
  I think we were a bit too loose at that point, compared to our signature. Most linalg operations in Base are restricted to such vectors anyway.
* make `alpha` and `beta` true and and false per default, consistent with `LinearAlgebra`'s 5-arg `mul!`.
* add docstrings