### PR TITLE
Use 5-arg mul! for matrices

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -106,10 +106,10 @@ function SparseArrays.sparse(A::LinearMap{T}) where {T}
 end
 
 include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
+include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I
 include("transpose.jl") # transposing linear maps
 include("linearcombination.jl") # defining linear combinations of linear maps
 include("composition.jl") # composition of linear maps
-include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I
 include("functionmap.jl") # using a function as linear map
 include("blockmap.jl") # block linear maps
 

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -105,10 +105,10 @@ function SparseArrays.sparse(A::LinearMap{T}) where {T}
     return SparseMatrixCSC(M, N, colptr, rowind, nzval)
 end
 
+include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
 include("transpose.jl") # transposing linear maps
 include("linearcombination.jl") # defining linear combinations of linear maps
 include("composition.jl") # composition of linear maps
-include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
 include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I
 include("functionmap.jl") # using a function as linear map
 include("blockmap.jl") # block linear maps

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -67,6 +67,14 @@ else # 5-arg mul! is available for matrices
 # map types that have an allocation-free 5-arg mul! implementation
 const FreeMap = Union{MatrixMap,UniformScalingMap}
 
+function A_mul_B!(y::AbstractVector, A::LinearCombination{T,As}, x::AbstractVector) where {T, As<:Tuple{Vararg{FreeMap}}}
+    # no size checking, will be done by individual maps
+    A_mul_B!(y, A.maps[1], x)
+    for n in 2:length(A.maps)
+        mul!(y, A.maps[n], x, true, true)
+    end
+    return y
+end
 function A_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector)
     # no size checking, will be done by individual maps
     A_mul_B!(y, A.maps[1], x)
@@ -82,14 +90,6 @@ function A_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector)
                 y .+= z
             end
         end
-    end
-    return y
-end
-function A_mul_B!(y::AbstractVector, A::LinearCombination{T,As}, x::AbstractVector) where {T, As<:Tuple{Vararg{FreeMap}}}
-    # no size checking, will be done by individual maps
-    A_mul_B!(y, A.maps[1], x)
-    for n in 2:length(A.maps)
-        mul!(y, A.maps[n], x, true, true)
     end
     return y
 end

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -17,6 +17,18 @@ function WrappedMap{T}(lmap::Union{AbstractMatrix, LinearMap};
     WrappedMap{T, typeof(lmap)}(lmap, issymmetric, ishermitian, isposdef)
 end
 
+if VERSION ≥ v"1.3.0-alpha.115"
+
+const MatrixMap{T} = WrappedMap{T,<:AbstractMatrix}
+
+transpose(A::MatrixMap) = LinearMap(transpose(A.lmap))
+adjoint(A::MatrixMap) = LinearMap(adjoint(A.lmap))
+
+LinearAlgebra.mul!(y::AbstractVector, A::MatrixMap, x::AbstractVector, α::Number=true, β::Number=false) =
+    mul!(y, A.lmap, x, α, β)
+
+end # VERSION
+
 # properties
 Base.size(A::WrappedMap) = size(A.lmap)
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -19,8 +19,8 @@ end
 
 const MatrixMap{T} = WrappedMap{T,<:AbstractMatrix}
 
-transpose(A::MatrixMap) = LinearMap(transpose(A.lmap))
-adjoint(A::MatrixMap) = LinearMap(adjoint(A.lmap))
+LinearAlgebra.transpose(A::MatrixMap) = LinearMap(transpose(A.lmap))
+LinearAlgebra.adjoint(A::MatrixMap) = LinearMap(adjoint(A.lmap))
 
 if VERSION ≥ v"1.3.0-alpha.115"
 

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -17,12 +17,12 @@ function WrappedMap{T}(lmap::Union{AbstractMatrix, LinearMap};
     WrappedMap{T, typeof(lmap)}(lmap, issymmetric, ishermitian, isposdef)
 end
 
-if VERSION ≥ v"1.3.0-alpha.115"
-
 const MatrixMap{T} = WrappedMap{T,<:AbstractMatrix}
 
 transpose(A::MatrixMap) = LinearMap(transpose(A.lmap))
 adjoint(A::MatrixMap) = LinearMap(adjoint(A.lmap))
+
+if VERSION ≥ v"1.3.0-alpha.115"
 
 LinearAlgebra.mul!(y::AbstractVector, A::MatrixMap, x::AbstractVector, α::Number=true, β::Number=false) =
     mul!(y, A.lmap, x, α, β)

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -19,8 +19,12 @@ end
 
 const MatrixMap{T} = WrappedMap{T,<:AbstractMatrix}
 
-LinearAlgebra.transpose(A::MatrixMap) = LinearMap(transpose(A.lmap))
-LinearAlgebra.adjoint(A::MatrixMap) = LinearMap(adjoint(A.lmap))
+LinearAlgebra.transpose(A::MatrixMap{T}) where {T} =
+    WrappedMap{T}(transpose(A.lmap); issymmetric=A._issymmetric, ishermitian=A._ishermitian, isposdef=A._isposdef)
+LinearAlgebra.adjoint(A::MatrixMap{T}) where {T} =
+    WrappedMap{T}(adjoint(A.lmap); issymmetric=A._issymmetric, ishermitian=A._ishermitian, isposdef=A._isposdef)
+
+Base.:(==)(A::MatrixMap, B::MatrixMap) = (eltype(A) == eltype(B) && A.lmap == B.lmap)
 
 if VERSION ≥ v"1.3.0-alpha.115"
 

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -28,7 +28,7 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) = (eltype(A) == eltype(B) && A.lmap == B.
 
 if VERSION ≥ v"1.3.0-alpha.115"
 
-LinearAlgebra.mul!(y::AbstractVector, A::MatrixMap, x::AbstractVector, α::Number=true, β::Number=false) =
+@inline LinearAlgebra.mul!(y::AbstractVector, A::MatrixMap, x::AbstractVector, α::Number=true, β::Number=false) =
     mul!(y, A.lmap, x, α, β)
 
 end # VERSION

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -28,7 +28,7 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) = (eltype(A) == eltype(B) && A.lmap == B.
 
 if VERSION ≥ v"1.3.0-alpha.115"
 
-@inline LinearAlgebra.mul!(y::AbstractVector, A::MatrixMap, x::AbstractVector, α::Number=true, β::Number=false) =
+LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector, α::Number=true, β::Number=false) =
     mul!(y, A.lmap, x, α, β)
 
 end # VERSION

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -24,7 +24,9 @@ LinearAlgebra.transpose(A::MatrixMap{T}) where {T} =
 LinearAlgebra.adjoint(A::MatrixMap{T}) where {T} =
     WrappedMap{T}(adjoint(A.lmap); issymmetric=A._issymmetric, ishermitian=A._ishermitian, isposdef=A._isposdef)
 
-Base.:(==)(A::MatrixMap, B::MatrixMap) = (eltype(A) == eltype(B) && A.lmap == B.lmap)
+Base.:(==)(A::MatrixMap, B::MatrixMap) =
+    (eltype(A)==eltype(B) && A.lmap==B.lmap && A._issymmetric==B._issymmetric &&
+     A._ishermitian==B._ishermitian && A._isposdef==B._isposdef)
 
 if VERSION ≥ v"1.3.0-alpha.115"
 

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -44,10 +44,10 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     @test @inferred convert(Matrix, M + LC) ≈ 2A + B
     @test @inferred convert(Matrix, M + M) ≈ 2A
     # subtraction
-    @test Matrix(LC - LC) ≈ zeros(eltype(LC), size(LC)) atol=10eps()
-    @test @inferred Matrix(LC - M) ≈ B
-    @test @inferred Matrix(N - LC) ≈ -A
-    @test Matrix(M - M) ≈ zeros(size(M)) atol=10eps()
+    @test (@inferred Matrix(LC - LC)) ≈ zeros(eltype(LC), size(LC)) atol=10eps()
+    @test (@inferred Matrix(LC - M)) ≈ B
+    @test (@inferred Matrix(N - LC)) ≈ -A
+    @test (@inferred Matrix(M - M)) ≈ zeros(size(M)) atol=10eps()
     # scalar multiplication
     @test @inferred Matrix(-M) == -A
     @test @inferred Matrix(-LC) == -A - B

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -29,6 +29,11 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
         for α in (false, true, rand(ComplexF64)), β in (false, true, rand(ComplexF64))
             b = @benchmarkable mul!($w, $LC, $v, $α, $β)
             @test run(b, samples=3).allocs == 0
+            b = @benchmarkable mul!($w, $(LC + I), $v, $α, $β)
+            @test run(b, samples=3).allocs == 0
+            y = rand(ComplexF64, size(v))
+            @test mul!(copy(y), LC, v, α, β) ≈ Matrix(LC)*v*α + y*β
+            @test mul!(copy(y), LC+I, v, α, β) ≈ Matrix(LC + I)*v*α + y*β
         end
     end
     # @test_throws ErrorException LinearMaps.LinearCombination{ComplexF64}((M, N), (1, 2, 3))
@@ -48,7 +53,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     @test @inferred Matrix(-LC) == -A - B
     @test @inferred Matrix(3 * M) == 3 * A
     @test @inferred Matrix(M * 3) == 3 * A
-    @test Matrix(3.0 * LC) ≈ Matrix(LC * 3) == 3A + 3B
+    @test Matrix(3.0 * LC) ≈ Matrix(LC * 3) ≈ 3A + 3B
     @test @inferred Matrix(3 \ M) ≈ A/3
     @test @inferred Matrix(M / 3) ≈ A/3
     @test @inferred Matrix(3 \ LC) ≈ (A + B) / 3

--- a/test/transpose.jl
+++ b/test/transpose.jl
@@ -49,4 +49,24 @@ using Test, LinearMaps, LinearAlgebra
     B = @inferred LinearMap(Hermitian(rand(ComplexF64, 10, 10)))
     @test adjoint(B) == B
     @test B == B'
+
+    CS = @inferred LinearMap{ComplexF64}(cumsum, x -> reverse(cumsum(reverse(x))), 10; ismutating=false)
+    for transform in (adjoint, transpose)
+        @test transform(transform(CS)) == CS
+    end
+    @test transpose(CS) != adjoint(CS)
+    @test adjoint(CS) != transpose(CS)
+    M = Matrix(CS)
+    x = rand(ComplexF64, 10)
+    for transform1 in (adjoint, transpose), transform2 in (adjoint, transpose)
+        @test transform2(LinearMap(transform1(CS))) * x ≈ transform2(transform1(M))*x
+    end
+
+    id = @inferred LinearMap(identity, identity, 10; issymmetric=true, ishermitian=true, isposdef=true)
+    for transform in (adjoint, transpose)
+        @test transform(id) == id
+        for prop in (issymmetric, ishermitian, isposdef)
+            @test prop(transform(id))
+        end
+    end
 end


### PR DESCRIPTION
Closes #56.

* introduce `MatrixMap{T} <: WrappedMap{T}`
* direct 5-arg mul! for MatrixMaps to `LinearAlgebra`'s 5-arg `mul!`
* make `MatrixMap` invariant under `adjoint`/`transpose`
* use this, if possible, in linear combinations