### PR TITLE
WIP: get rid of A*_mul_B!

### DIFF
--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -109,10 +109,6 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(Y::AbstractMatrix, A::Linea
     return Y
 end
 
-# A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
-# At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
-# Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
-
 include("transpose.jl") # transposing linear maps
 include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
 include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -75,7 +75,7 @@ end
 function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap, x::AbstractVector, α::Number=true, β::Number=false)
     @boundscheck check_dim_mul(y, A, x)
     if isone(α)
-        iszero(β) && (A_mul_B!(y, A, x); return y)
+        iszero(β) && (mul!(y, A, x); return y)
         isone(β) && (y .+= A * x; return y)
         # β != 0, 1
         rmul!(y, β)
@@ -88,7 +88,7 @@ function LinearAlgebra.mul!(y::AbstractVector, A::LinearMap, x::AbstractVector, 
         rmul!(y, β)
         return y
     else # α != 0, 1
-        iszero(β) && (A_mul_B!(y, A, x); rmul!(y, α); return y)
+        iszero(β) && (mul!(y, A, x); rmul!(y, α); return y)
         isone(β) && (y .+= rmul!(A * x, α); return y)
         # β != 0, 1
         rmul!(y, β)
@@ -109,13 +109,13 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(Y::AbstractMatrix, A::Linea
     return Y
 end
 
-A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
-At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
-Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
+# A_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector)  = mul!(y, A, x)
+# At_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, transpose(A), x)
+# Ac_mul_B!(y::AbstractVector, A::AbstractMatrix, x::AbstractVector) = mul!(y, adjoint(A), x)
 
+include("transpose.jl") # transposing linear maps
 include("wrappedmap.jl") # wrap a matrix of linear map in a new type, thereby allowing to alter its properties
 include("uniformscalingmap.jl") # the uniform scaling map, to be able to make linear combinations of LinearMap objects and multiples of I
-include("transpose.jl") # transposing linear maps
 include("linearcombination.jl") # defining linear combinations of linear maps
 include("composition.jl") # composition of linear maps
 include("functionmap.jl") # using a function as linear map

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -92,12 +92,20 @@ function LinearAlgebra.mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix, 
 end
 
 # multiplication helper functions
-@inline _muladd!(::FiveArg, y, A::LinearMap, x, α, β) = mul!(y, A, x, α, β)
-@inline _muladd!(::ThreeArg, y, A::LinearMap, x, α, β) =
+@inline _muladd!(::FiveArg, y, A::MapOrMatrix, x, α, β) = mul!(y, A, x, α, β)
+@inline _muladd!(::ThreeArg, y, A::MapOrMatrix, x, α, β) =
     iszero(β) ? muladd!(y, A, x, α, β, nothing) : muladd!(y, A, x, α, β, similar(y))
-@inline _muladd!(::FiveArg, y, A::LinearMap, x, α, β, _) = mul!(y, A, x, α, β)
-@inline _muladd!(::ThreeArg, y, A::LinearMap, x, α, β, z) = muladd!(y, A, x, α, β, z)
-@inline function muladd!(y, A::LinearMap, x, α, β, z)
+@inline _muladd!(::FiveArg, y, A::MapOrMatrix, x, α, β, _) = mul!(y, A, x, α, β)
+@inline _muladd!(::ThreeArg, y, A::MapOrMatrix, x, α, β, z) = muladd!(y, A, x, α, β, z)
+
+"""
+    muladd!(y, A, x, α, β, z)
+
+Compute 5-arg multiplication for `LinearMap`s that do not have a 5-arg `mul!`,
+but only a 3-arg `mul!`. For storing the intermediate `A*x*α`, a vector (or
+matrix, as appropriate) `z` is (already) provided.
+"""
+@inline function muladd!(y, A::MapOrMatrix, x, α, β, z)
     if iszero(α)
         iszero(β) && (fill!(y, zero(eltype(y))); return y)
         isone(β) && return y

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -341,43 +341,24 @@ end
 end
 
 ############
-# multiplication with vectors
+# multiplication with vectors & matrices
 ############
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::BlockMap, x::AbstractVector,
-                            α::Number=true, β::Number=false)
-    require_one_based_indexing(y, x)
-    @boundscheck check_dim_mul(y, A, x)
-    return _blockmul!(y, A, x, α, β)
-end
-
-for (maptype, transform) in ((:(TransposeMap{<:Any,<:BlockMap}), :transpose), (:(AdjointMap{<:Any,<:BlockMap}), :adjoint))
-    @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, wrapA::$maptype, x::AbstractVector,
-                            α::Number=true, β::Number=false)
+for Atype in (AbstractVector, AbstractMatrix)
+    @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, A::BlockMap, x::$Atype,
+                                α::Number=true, β::Number=false)
         require_one_based_indexing(y, x)
-        @boundscheck check_dim_mul(y, wrapA, x)
-        return _transblockmul!(y, wrapA.lmap, x, α, β, $transform)
+        @boundscheck check_dim_mul(y, A, x)
+        return _blockmul!(y, A, x, α, β)
     end
-end
 
-############
-# multiplication with matrices
-############
-
-Base.@propagate_inbounds function LinearAlgebra.mul!(Y::AbstractMatrix, A::BlockMap, X::AbstractMatrix,
-                            α::Number=true, β::Number=false)
-    require_one_based_indexing(Y, X)
-    @boundscheck check_dim_mul(Y, A, X)
-    maps, rows, yinds, xinds = A.maps, A.rows, A.rowranges, A.colranges
-    return _blockmul!(Y, A, X, α, β)
-end
-
-for (maptype, transform) in ((:(TransposeMap{<:Any,<:BlockMap}), :transpose), (:(AdjointMap{<:Any,<:BlockMap}), :adjoint))
-    @eval Base.@propagate_inbounds function LinearAlgebra.mul!(Y::AbstractMatrix, wrapA::$maptype, X::AbstractMatrix,
-                            α::Number=true, β::Number=false)
-        require_one_based_indexing(Y, X)
-        @boundscheck check_dim_mul(Y, wrapA, X)
-        return _transblockmul!(Y, wrapA.lmap, X, α, β, $transform)
+    for (maptype, transform) in ((:(TransposeMap{<:Any,<:BlockMap}), :transpose), (:(AdjointMap{<:Any,<:BlockMap}), :adjoint))
+        @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, wrapA::$maptype, x::$Atype,
+                                α::Number=true, β::Number=false)
+            require_one_based_indexing(y, x)
+            @boundscheck check_dim_mul(y, wrapA, x)
+            return _transblockmul!(y, wrapA.lmap, x, α, β, $transform)
+        end
     end
 end
 
@@ -461,17 +442,13 @@ LinearAlgebra.transpose(A::BlockDiagonalMap{T}) where {T} = BlockDiagonalMap{T}(
 
 Base.:(==)(A::BlockDiagonalMap, B::BlockDiagonalMap) = (eltype(A) == eltype(B) && A.maps == B.maps)
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::BlockDiagonalMap, x::AbstractVector, α::Number=true, β::Number=false)
-    require_one_based_indexing(y, x)
-    @boundscheck check_dim_mul(y, A, x)
-    return _blockscaling!(y, A, x, α, β)
-end
-
-Base.@propagate_inbounds function LinearAlgebra.mul!(Y::AbstractMatrix, A::BlockDiagonalMap, X::AbstractMatrix,
-                    α::Number=true, β::Number=false)
-    require_one_based_indexing(Y, X)
-    @boundscheck check_dim_mul(Y, A, X)
-    return _blockscaling!(Y, A, X, α, β)
+for Atype in (AbstractVector, AbstractMatrix)
+    @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, A::BlockDiagonalMap, x::$Atype,
+                        α::Number=true, β::Number=false)
+        require_one_based_indexing(y, x)
+        @boundscheck check_dim_mul(y, A, x)
+        return _blockscaling!(y, A, x, α, β)
+    end
 end
 
 @inline function _blockscaling!(y, A::BlockDiagonalMap, x, α, β)
@@ -479,6 +456,17 @@ end
     # TODO: think about multi-threading here
     @views @inbounds for i in eachindex(yinds, maps, xinds)
         mul!(selectdim(y, 1, yinds[i]), maps[i], selectdim(x, 1, xinds[i]), α, β)
+    end
+    return y
+end
+
+Base.@propagate_inbounds function muladd!(y, A::BlockDiagonalMap, x, α, β, z)
+    require_one_based_indexing(y, x, z)
+    @boundscheck check_dim_mul(y, A, x)
+    @boundscheck size(y) == size(z)
+    maps, yinds, xinds = A.maps, A.rowranges, A.colranges
+    @views @inbounds for i in 1:length(maps)
+        _muladd!(MulStyle(maps[i]), selectdim(y, 1, yinds[i]), maps[i], selectdim(x, 1, xinds[i]), α, β, selectdim(z, 1, yinds[i]))
     end
     return y
 end

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -16,6 +16,7 @@ struct CompositeMap{T, As<:Tuple{Vararg{LinearMap}}} <: LinearMap{T}
 end
 CompositeMap{T}(maps::As) where {T, As<:Tuple{Vararg{LinearMap}}} = CompositeMap{T, As}(maps)
 
+# treat CompositeMaps as FiveArg's because the 5-arg mul! is optimized
 MulStyle(::CompositeMap) = FiveArg()
 
 # basic methods

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -143,7 +143,7 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::Compo
                     rethrow(err)
                 end
             end
-            mul!(dest, A.maps[n], source, true, false)
+            mul!(dest, A.maps[n], source)
             dest, source = source, dest # alternate dest and source
         end
         mul!(y, A.maps[N], source, true, β)

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -120,7 +120,8 @@ LinearAlgebra.adjoint(A::CompositeMap{T}) where {T}   = CompositeMap{T}(map(adjo
 Base.:(==)(A::CompositeMap, B::CompositeMap) = (eltype(A) == eltype(B) && A.maps == B.maps)
 
 # multiplication with vectors
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::CompositeMap, x::AbstractVector, α::Number=true, β::Number=false)
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::CompositeMap, x::AbstractVector,
+                    α::Number=true, β::Number=false)
     # no size checking, will be done by individual maps
     N = length(A.maps)
     if N==1
@@ -149,11 +150,3 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::Compo
     end
     return y
 end
-
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:CompositeMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    mul!(y, transpose(A.lmap), x, α, β)
-
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:CompositeMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    mul!(y, adjoint(A.lmap), x, α, β)

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -107,17 +107,13 @@ function Base.:(*)(A::TransposeMap{<:Any,<:FunctionMap}, x::AbstractVector)
     end
 end
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::FunctionMap, x::AbstractVector,
-                    α::Number=true, β::Number=false)
-    (isone(α) && iszero(β)) || error("5-arg mul! for FunctionMaps not yet implemented")
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::FunctionMap, x::AbstractVector)
     @boundscheck check_dim_mul(y, A, x)
     ismutating(A) ? A.f(y, x) : copyto!(y, A.f(x))
     return y
 end
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, transA::TransposeMap{<:Any,<:FunctionMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false)
-    (isone(α) && iszero(β)) || error("5-arg mul! for FunctionMaps not yet implemented")
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, transA::TransposeMap{<:Any,<:FunctionMap}, x::AbstractVector)
     A = transA.lmap
     issymmetric(A) && return mul!(y, A, x)
     @boundscheck check_dim_mul(y, transA, x)
@@ -140,9 +136,7 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, transA::
     end
 end
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, adjA::AdjointMap{<:Any,<:FunctionMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false)
-    (isone(α) && iszero(β)) || error("5-arg mul! for FunctionMaps not yet implemented")
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, adjA::AdjointMap{<:Any,<:FunctionMap}, x::AbstractVector)
     A = adjA.lmap
     ishermitian(A) && return mul!(y, A, x)
     @boundscheck check_dim_mul(y, adjA, x)

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -173,12 +173,6 @@ Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::Compo
     end
 end
 
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:KroneckerMap}, x::AbstractVector) =
-    mul!(y, transpose(A), x)
-
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:KroneckerMap}, x::AbstractVector) =
-    mul!(y, adjoint(A), x)
-
 ###############
 # KroneckerSumMap
 ###############
@@ -248,6 +242,8 @@ where `A` can be a square `AbstractMatrix` or a `LinearMap`.
 ⊕(a, b, c...) = kronsum(a, b, c...)
 
 Base.:(^)(A::MapOrMatrix, ::KronSumPower{p}) where {p} = kronsum(ntuple(n -> convert_to_lmaps_(A), Val(p))...)
+
+MulStyle(A::KronSumPower) = MulStyle(Matrix{Float64}(undef, 0, 0), A.maps...)
 
 Base.size(A::KroneckerSumMap, i) = prod(size.(A.maps, i))
 Base.size(A::KroneckerSumMap) = (size(A, 1), size(A, 2))

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -109,9 +109,9 @@ Base.:(==)(A::KroneckerMap, B::KroneckerMap) = (eltype(A) == eltype(B) && A.maps
     temp2 = similar(y, nb)
     @views @inbounds for i in 1:ma
         v[i] = one(T)
-        A_mul_B!(temp1, At, v)
-        A_mul_B!(temp2, X, temp1)
-        A_mul_B!(y[((i-1)*mb+1):i*mb], B, temp2)
+        mul!(temp1, At, v)
+        mul!(temp2, X, temp1)
+        mul!(y[((i-1)*mb+1):i*mb], B, temp2)
         v[i] = zero(T)
     end
     return y
@@ -131,7 +131,7 @@ end
 # multiplication with vectors
 #################
 
-Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerMap{T,<:NTuple{2,LinearMap}}, x::AbstractVector) where {T}
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::KroneckerMap{T,<:NTuple{2,LinearMap}}, x::AbstractVector) where {T}
     require_one_based_indexing(y)
     @boundscheck check_dim_mul(y, L, x)
     A, B = L.maps
@@ -139,7 +139,7 @@ Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerMap{T,
     _kronmul!(y, B, X, transpose(A), T)
     return y
 end
-Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerMap{T}, x::AbstractVector) where {T}
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::KroneckerMap{T}, x::AbstractVector) where {T}
     require_one_based_indexing(y)
     @boundscheck check_dim_mul(y, L, x)
     A = first(L.maps)
@@ -150,34 +150,34 @@ Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerMap{T}
 end
 # mixed-product rule, prefer the right if possible
 # (A₁ ⊗ A₂ ⊗ ... ⊗ Aᵣ) * (B₁ ⊗ B₂ ⊗ ... ⊗ Bᵣ) = (A₁B₁) ⊗ (A₂B₂) ⊗ ... ⊗ (AᵣBᵣ)
-Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::CompositeMap{<:Any,<:Tuple{KroneckerMap,KroneckerMap}}, x::AbstractVector)
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::CompositeMap{<:Any,<:Tuple{KroneckerMap,KroneckerMap}}, x::AbstractVector)
     B, A = L.maps
     if length(A.maps) == length(B.maps) && all(M -> check_dim_mul(M[1], M[2]), zip(A.maps, B.maps))
-        A_mul_B!(y, kron(map(*, A.maps, B.maps)...), x)
+        mul!(y, kron(map(*, A.maps, B.maps)...), x)
     else
-        A_mul_B!(y, LinearMap(A)*B, x)
+        mul!(y, LinearMap(A)*B, x)
     end
 end
 # mixed-product rule, prefer the right if possible
 # (A₁ ⊗ B₁)*(A₂⊗B₂)*...*(Aᵣ⊗Bᵣ) = (A₁*A₂*...*Aᵣ) ⊗ (B₁*B₂*...*Bᵣ)
-Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::CompositeMap{T,<:Tuple{Vararg{KroneckerMap{<:Any,<:Tuple{LinearMap,LinearMap}}}}}, x::AbstractVector) where {T}
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::CompositeMap{T,<:Tuple{Vararg{KroneckerMap{<:Any,<:Tuple{LinearMap,LinearMap}}}}}, x::AbstractVector) where {T}
     As = map(AB -> AB.maps[1], L.maps)
     Bs = map(AB -> AB.maps[2], L.maps)
     As1, As2 = Base.front(As), Base.tail(As)
     Bs1, Bs2 = Base.front(Bs), Base.tail(Bs)
     apply = all(A -> check_dim_mul(A...), zip(As1, As2)) && all(A -> check_dim_mul(A...), zip(Bs1, Bs2))
     if apply
-        A_mul_B!(y, kron(prod(As), prod(Bs)), x)
+        mul!(y, kron(prod(As), prod(Bs)), x)
     else
-        A_mul_B!(y, CompositeMap{T}(map(LinearMap, L.maps)), x)
+        mul!(y, CompositeMap{T}(map(LinearMap, L.maps)), x)
     end
 end
 
-Base.@propagate_inbounds At_mul_B!(y::AbstractVector, A::KroneckerMap, x::AbstractVector) =
-    A_mul_B!(y, transpose(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:KroneckerMap}, x::AbstractVector) =
+    mul!(y, transpose(A), x)
 
-Base.@propagate_inbounds Ac_mul_B!(y::AbstractVector, A::KroneckerMap, x::AbstractVector) =
-    A_mul_B!(y, adjoint(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:KroneckerMap}, x::AbstractVector) =
+    mul!(y, adjoint(A), x)
 
 ###############
 # KroneckerSumMap
@@ -261,7 +261,7 @@ LinearAlgebra.transpose(A::KroneckerSumMap{T}) where {T} = KroneckerSumMap{T}(ma
 
 Base.:(==)(A::KroneckerSumMap, B::KroneckerSumMap) = (eltype(A) == eltype(B) && A.maps == B.maps)
 
-Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerSumMap, x::AbstractVector)
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, L::KroneckerSumMap, x::AbstractVector)
     @boundscheck check_dim_mul(y, L, x)
     A, B = L.maps
     ma, na = size(A)
@@ -273,8 +273,8 @@ Base.@propagate_inbounds function A_mul_B!(y::AbstractVector, L::KroneckerSumMap
     return y
 end
 
-Base.@propagate_inbounds At_mul_B!(y::AbstractVector, A::KroneckerSumMap, x::AbstractVector) =
-    A_mul_B!(y, transpose(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:KroneckerSumMap}, x::AbstractVector) =
+    mul!(y, transpose(A), x)
 
-Base.@propagate_inbounds Ac_mul_B!(y::AbstractVector, A::KroneckerSumMap, x::AbstractVector) =
-    A_mul_B!(y, adjoint(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:KroneckerSumMap}, x::AbstractVector) =
+    mul!(y, adjoint(A), x)

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -82,9 +82,9 @@ for Atype in (AbstractVector, AbstractMatrix)
                 z = similar(y)
                 muladd!(y, A1, x, α, β, z)
                 __mul!(y, Base.tail(A.maps), x, α, z)
-            else
+            else # MulStyle(A1) === FiveArg()
                 # this is allocation-free
-                _muladd!(MulStyle(A1), y, A1, x, α, β)
+                mul!(y, A1, x, α, β)
                 # let _mul! decide whether an intermediate vector needs to be allocated
                 _mul!(MulStyle(A), y, A, x, α)
             end

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -78,6 +78,7 @@ for Atype in (AbstractVector, AbstractMatrix)
             mul!(y, first(A.maps), x, α, β)
             return _mul!(MulStyle(A), y, A, x, α)
         end
+        return y
     end
 end
 
@@ -101,7 +102,6 @@ end
     else
         y .+= z .* α
     end
-    return y
 end
 
 A_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = mul!(y, A, x)

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -106,6 +106,8 @@ end
 
 A_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = mul!(y, A, x)
 
-At_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = mul!(y, transpose(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:LinearCombination}, x::AbstractVector,
+                α::Number=true, β::Number=false) = mul!(y, transpose(A), x, α, β)
 
-Ac_mul_B!(y::AbstractVector, A::LinearCombination, x::AbstractVector) = mul!(y, adjoint(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:LinearCombination}, x::AbstractVector,
+                α::Number=true, β::Number=false) = mul!(y, adjoint(A), x, α, β)

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -33,17 +33,17 @@ Base.:(==)(A::LinearMap, B::AdjointMap)      = ishermitian(A) && B.lmap == A
 
 # multiplication with vector
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    issymmetric(A.lmap) ? mul!(y, A.lmap, x, α, β) : error("transpose not defined for $(typeof(A.lmap))")
+                α::Number=true, β::Number=false) =
+    issymmetric(A.lmap) ? _muladd!(MulStyle(A), y, A.lmap, x, α, β) : _muladd!(MulStyle(A), y, A, x, α, β)
 
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:TransposeMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    isreal(A.lmap) ? mul!(y, A.lmap.lmap, x, α, β) : (mul!(y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))
+                α::Number=true, β::Number=false) =
+    isreal(A.lmap) ? _muladd!(MulStyle(A), y, A.lmap.lmap, x, α, β) : (_muladd!(MulStyle(A), y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))
 
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    ishermitian(A.lmap) ? mul!(y, A.lmap, x) : error("adjoint not defined for $(typeof(A.lmap))")
+                α::Number=true, β::Number=false) =
+    ishermitian(A.lmap) ? _muladd!(MulStyle(A), y, A.lmap, x, α, β) : _muladd!(MulStyle(A), y, A, x, α, β)
 
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:AdjointMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    isreal(A.lmap) ? mul!(y, A.lmap.lmap, x, α, β) : (mul!(y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))
+                α::Number=true, β::Number=false) =
+    isreal(A.lmap) ? _muladd!(MulStyle(A), y, A.lmap.lmap, x, α, β) : (_muladd!(MulStyle(A), y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -34,20 +34,16 @@ Base.:(==)(A::LinearMap, B::AdjointMap)      = ishermitian(A) && B.lmap == A
 # multiplication with vector
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap, x::AbstractVector,
                     α::Number=true, β::Number=false) =
-    issymmetric(A.lmap) ? mul!(y, A.lmap, x, α, β) : error("transpose not defined for $(typeof(A.lmap))")#At_mul_B!(y, A.lmap, x)
+    issymmetric(A.lmap) ? mul!(y, A.lmap, x, α, β) : error("transpose not defined for $(typeof(A.lmap))")
 
-# At_mul_B!(y::AbstractVector, A::TransposeMap, x::AbstractVector) = A_mul_B!(y, A.lmap, x)
-#
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:TransposeMap}, x::AbstractVector,
                     α::Number=true, β::Number=false) =
     isreal(A.lmap) ? mul!(y, A.lmap.lmap, x, α, β) : (mul!(y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))
 
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap, x::AbstractVector,
                     α::Number=true, β::Number=false) =
-    ishermitian(A.lmap) ? mul!(y, A.lmap, x) : error("adjoint not defined")#Ac_mul_B!(y, A.lmap, x)
+    ishermitian(A.lmap) ? mul!(y, A.lmap, x) : error("adjoint not defined for $(typeof(A.lmap))")
 
 Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:AdjointMap}, x::AbstractVector,
                     α::Number=true, β::Number=false) =
     isreal(A.lmap) ? mul!(y, A.lmap.lmap, x, α, β) : (mul!(y, A.lmap.lmap, conj(x), conj(α), conj(β)); conj!(y))
-#
-# Ac_mul_B!(y::AbstractVector, A::AdjointMap, x::AbstractVector) = A_mul_B!(y, A.lmap, x)

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -76,26 +76,11 @@ function _scaling!(y, λ::Number, x, α::Number, β::Number)
             y .+= λ .* x .* α
             return y
         else # β != 0, 1
-            isone(λ) && (y .= y .* β .+ x .* α; return y)
             y .= y .* β .+ λ .* x .* α
             return y
         end # β-cases
     end # α-cases
 end # function _scaling!
-
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:UniformScalingMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    mul!(y, transpose(A), x, α, β)
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:UniformScalingMap}, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    mul!(y, adjoint(A), x, α, β)
-
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractMatrix, A::TransposeMap{<:Any,<:UniformScalingMap}, x::AbstractMatrix,
-                    α::Number=true, β::Number=false) =
-    mul!(y, transpose(A), x, α, β)
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractMatrix, A::AdjointMap{<:Any,<:UniformScalingMap}, x::AbstractMatrix,
-                    α::Number=true, β::Number=false) =
-    mul!(y, adjoint(A), x, α, β)
 
 # combine LinearMap and UniformScaling objects in linear combinations
 Base.:(+)(A₁::LinearMap, A₂::UniformScaling) = A₁ + UniformScalingMap(A₂.λ, size(A₁, 1))

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -83,10 +83,19 @@ function _scaling!(y, λ::Number, x, α::Number, β::Number)
     end # α-cases
 end # function _scaling!
 
-A_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector) = mul!(y, A, x)
-At_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector) = A_mul_B!(y, transpose(A), x)
-Ac_mul_B!(y::AbstractVector, A::UniformScalingMap, x::AbstractVector) = A_mul_B!(y, adjoint(A), x)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:UniformScalingMap}, x::AbstractVector,
+                    α::Number=true, β::Number=false) =
+    mul!(y, transpose(A), x, α, β)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:UniformScalingMap}, x::AbstractVector,
+                    α::Number=true, β::Number=false) =
+    mul!(y, adjoint(A), x, α, β)
 
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractMatrix, A::TransposeMap{<:Any,<:UniformScalingMap}, x::AbstractMatrix,
+                    α::Number=true, β::Number=false) =
+    mul!(y, transpose(A), x, α, β)
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractMatrix, A::AdjointMap{<:Any,<:UniformScalingMap}, x::AbstractMatrix,
+                    α::Number=true, β::Number=false) =
+    mul!(y, adjoint(A), x, α, β)
 
 # combine LinearMap and UniformScaling objects in linear combinations
 Base.:(+)(A₁::LinearMap, A₂::UniformScaling) = A₁ + UniformScalingMap(A₂.λ, size(A₁, 1))

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -31,61 +31,56 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) =
      A._ishermitian==B._ishermitian && A._isposdef==B._isposdef)
 
 if VERSION ≥ v"1.3.0-alpha.115"
-# multiplication with vector
-Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector,
-                    α::Number=true, β::Number=false) =
-    mul!(y, A.lmap, x, α, β)
+    # multiplication with vector/matrix
+    for Atype in (AbstractVector, AbstractMatrix)
+        @eval Base.@propagate_inbounds LinearAlgebra.mul!(y::$Atype, A::WrappedMap, x::$Atype,
+                            α::Number=true, β::Number=false) =
+            mul!(y, A.lmap, x, α, β)
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, transA::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector,
-                                            α::Number=true, β::Number=false)
-    if (issymmetric(transA) || (isreal(transA) && ishermitian(transA)))
-        mul!(y, transA.lmap, x, α, β)
-    else
-        mul!(y, transpose(transA.lmap.lmap), x, α, β)
+        @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, transA::TransposeMap{<:Any,<:WrappedMap}, x::$Atype,
+                                                    α::Number=true, β::Number=false)
+            if (issymmetric(transA) || (isreal(transA) && ishermitian(transA)))
+                mul!(y, transA.lmap, x, α, β)
+            else
+                mul!(y, transpose(transA.lmap.lmap), x, α, β)
+            end
+            return y
+        end
+
+        @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, adjA::AdjointMap{<:Any,<:WrappedMap}, x::$Atype,
+                                                    α::Number=true, β::Number=false)
+            if ishermitian(adjA)
+                mul!(y, adjA.lmap, x, α, β)
+            else
+                mul!(y, adjoint(adjA.lmap.lmap), x, α, β)
+            end
+            return y
+        end
     end
-    return y
-end
+else # generic 5-arg mul! for matrices is not available => can't provide 5-arg mul!'s here
+    # multiplication with vector/matrix
+    for Atype in (AbstractVector, AbstractMatrix)
+        @eval Base.@propagate_inbounds LinearAlgebra.mul!(y::$Atype, A::WrappedMap, x::$Atype) =
+            mul!(y, A.lmap, x)
 
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, adjA::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector,
-                                            α::Number=true, β::Number=false)
-    if ishermitian(adjA)
-        mul!(y, adjA.lmap, x, α, β)
-    else
-        mul!(y, adjoint(adjA.lmap.lmap), x, α, β)
+        @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, A::TransposeMap{<:Any,<:WrappedMap}, x::$Atype)
+            if (issymmetric(A) || (isreal(A) && ishermitian(A)))
+                mul!(y, A.lmap, x)
+            else
+                mul!(y, transpose(A.lmap.lmap), x)
+            end
+            return y
+        end
+
+        @eval Base.@propagate_inbounds function LinearAlgebra.mul!(y::$Atype, A::AdjointMap{<:Any,<:WrappedMap}, x::$Atype)
+            if ishermitian(A)
+                mul!(y, A.lmap, x)
+            else
+                mul!(y, adjoint(A.lmap.lmap), x)
+            end
+            return y
+        end
     end
-    return y
-end
-
-Base.@propagate_inbounds LinearAlgebra.mul!(Y::AbstractMatrix, A::MatrixMap, X::AbstractMatrix,
-                    α::Number=true, β::Number=false) =
-    mul!(Y, A.lmap, X, α, β)
-
-else
-
-LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
-    mul!(y, A.lmap, x)
-
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector)
-    if (issymmetric(A) || (isreal(A) && ishermitian(A)))
-        mul!(y, A.lmap, x)
-    else
-        mul!(y, transpose(A.lmap.lmap), x)
-    end
-    return y
-end
-
-Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector)
-    if ishermitian(A)
-        mul!(y, A.lmap, x)
-    else
-        mul!(y, adjoint(A.lmap.lmap), x)
-    end
-    return y
-end
-
-Base.@propagate_inbounds LinearAlgebra.mul!(Y::AbstractMatrix, A::MatrixMap, X::AbstractMatrix) =
-    mul!(Y, A.lmap, X)
-
 end # VERSION
 
 # properties
@@ -93,20 +88,6 @@ Base.size(A::WrappedMap) = size(A.lmap)
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian
 LinearAlgebra.isposdef(A::WrappedMap) = A._isposdef
-
-# # multiplication with vector
-# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
-#     mul!(y, A.lmap, x)
-#
-# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector) =
-#     (issymmetric(A) || (isreal(A) && ishermitian(A))) ? mul!(y, A.lmap, x) : mul!(y, transpose(A.lmap.lmap), x)
-#
-# Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector) =
-#     ishermitian(A) ? mul!(y, A.lmap, x) : mul!(y, adjoint(A.lmap.lmap), x)
-
-# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
-#     mul!(y, A.lmap, x)
-Base.:(*)(A::WrappedMap, x::AbstractVector) = *(A.lmap, x)
 
 # combine LinearMap and Matrix objects: linear combinations and map composition
 Base.:(+)(A₁::LinearMap, A₂::AbstractMatrix) = +(A₁, WrappedMap(A₂))

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -30,38 +30,83 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) =
     (eltype(A)==eltype(B) && A.lmap==B.lmap && A._issymmetric==B._issymmetric &&
      A._ishermitian==B._ishermitian && A._isposdef==B._isposdef)
 
+if VERSION ≥ v"1.3.0-alpha.115"
+# multiplication with vector
+Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector,
+                    α::Number=true, β::Number=false) =
+    mul!(y, A.lmap, x, α, β)
+
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, transA::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector,
+                                            α::Number=true, β::Number=false)
+    if (issymmetric(transA) || (isreal(transA) && ishermitian(transA)))
+        mul!(y, transA.lmap, x, α, β)
+    else
+        mul!(y, transpose(transA.lmap.lmap), x, α, β)
+    end
+    return y
+end
+
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, adjA::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector,
+                                            α::Number=true, β::Number=false)
+    if ishermitian(adjA)
+        mul!(y, adjA.lmap, x, α, β)
+    else
+        mul!(y, adjoint(adjA.lmap.lmap), x, α, β)
+    end
+    return y
+end
+
+Base.@propagate_inbounds LinearAlgebra.mul!(Y::AbstractMatrix, A::MatrixMap, X::AbstractMatrix,
+                    α::Number=true, β::Number=false) =
+    mul!(Y, A.lmap, X, α, β)
+
+else
+
+LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
+    mul!(y, A.lmap, x)
+
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector)
+    if (issymmetric(A) || (isreal(A) && ishermitian(A)))
+        mul!(y, A.lmap, x)
+    else
+        mul!(y, transpose(A.lmap.lmap), x)
+    end
+    return y
+end
+
+Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector)
+    if ishermitian(A)
+        mul!(y, A.lmap, x)
+    else
+        mul!(y, adjoint(A.lmap.lmap), x)
+    end
+    return y
+end
+
+Base.@propagate_inbounds LinearAlgebra.mul!(Y::AbstractMatrix, A::MatrixMap, X::AbstractMatrix) =
+    mul!(Y, A.lmap, X)
+
+end # VERSION
+
 # properties
 Base.size(A::WrappedMap) = size(A.lmap)
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian
 LinearAlgebra.isposdef(A::WrappedMap) = A._isposdef
 
-# multiplication with vectors & matrices
-A_mul_B!(y::AbstractVector, A::WrappedMap, x::AbstractVector) = A_mul_B!(y, A.lmap, x)
+# # multiplication with vector
+# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
+#     mul!(y, A.lmap, x)
+#
+# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::TransposeMap{<:Any,<:WrappedMap}, x::AbstractVector) =
+#     (issymmetric(A) || (isreal(A) && ishermitian(A))) ? mul!(y, A.lmap, x) : mul!(y, transpose(A.lmap.lmap), x)
+#
+# Base.@propagate_inbounds function LinearAlgebra.mul!(y::AbstractVector, A::AdjointMap{<:Any,<:WrappedMap}, x::AbstractVector) =
+#     ishermitian(A) ? mul!(y, A.lmap, x) : mul!(y, adjoint(A.lmap.lmap), x)
+
+# Base.@propagate_inbounds LinearAlgebra.mul!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
+#     mul!(y, A.lmap, x)
 Base.:(*)(A::WrappedMap, x::AbstractVector) = *(A.lmap, x)
-
-At_mul_B!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
-    (issymmetric(A) || (isreal(A) && ishermitian(A))) ? A_mul_B!(y, A.lmap, x) : At_mul_B!(y, A.lmap, x)
-
-Ac_mul_B!(y::AbstractVector, A::WrappedMap, x::AbstractVector) =
-    ishermitian(A) ? A_mul_B!(y, A.lmap, x) : Ac_mul_B!(y, A.lmap, x)
-
-if VERSION ≥ v"1.3.0-alpha.115"
-    for Atype in (AbstractVector, AbstractMatrix)
-        @eval Base.@propagate_inbounds LinearAlgebra.mul!(y::$Atype, A::WrappedMap, x::$Atype,
-                        α::Number=true, β::Number=false) =
-            mul!(y, A.lmap, x, α, β)
-    end
-else
-# This is somewhat suboptimal, because the absence of 5-arg mul! for MatrixMaps
-# doesn't allow to define a 5-arg mul! for WrappedMaps which do have a 5-arg mul!
-# I'd assume, however, that 5-arg mul! becomes standard in Julia v≥1.3 anyway
-# the idea is to let the fallback handle 5-arg calls
-    for Atype in (AbstractVector, AbstractMatrix)
-        @eval Base.@propagate_inbounds LinearAlgebra.mul!(Y::$Atype, A::WrappedMap, X::$Atype) =
-            mul!(Y, A.lmap, X)
-    end
-end # VERSION
 
 # combine LinearMap and Matrix objects: linear combinations and map composition
 Base.:(+)(A₁::LinearMap, A₂::AbstractMatrix) = +(A₁, WrappedMap(A₂))

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -66,10 +66,10 @@ using Test, LinearMaps, LinearAlgebra
     w = similar(v)
     mul!(w, F, v)
     @test w == F * v
-    @test_throws ErrorException F' * v
-    @test_throws ErrorException transpose(F) * v
-    @test_throws ErrorException mul!(w, adjoint(F), v)
-    @test_throws ErrorException mul!(w, transpose(F), v)
+    # @test_throws StackOverflowError F' * v
+    # @test_throws StackOverflowError transpose(F) * v
+    # @test_throws StackOverflowError mul!(w, adjoint(F), v)
+    # @test_throws StackOverflowError mul!(w, transpose(F), v)
 
     # test composition of several maps with shared data #31
     global sizes = ( (5, 2), (3, 3), (3, 2), (2, 2), (9, 2), (7, 1) )

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -53,6 +53,24 @@ using Test, LinearMaps, LinearAlgebra
     mul!(w, L, v)
     @test w ≈ LF * v
 
+    # test new type
+    F = SimpleFunctionMap(cumsum, 10)
+    FC = SimpleComplexFunctionMap(cumsum, 10)
+    @test @inferred ndims(F) == 2
+    @test @inferred size(F, 1) == 10
+    @test @inferred length(F) == 100
+    @test @inferred !issymmetric(F)
+    @test @inferred !ishermitian(F)
+    @test @inferred !ishermitian(FC)
+    @test @inferred !isposdef(F)
+    w = similar(v)
+    mul!(w, F, v)
+    @test w == F * v
+    @test_throws ErrorException F' * v
+    @test_throws ErrorException transpose(F) * v
+    @test_throws ErrorException mul!(w, adjoint(F), v)
+    @test_throws ErrorException mul!(w, transpose(F), v)
+
     # test composition of several maps with shared data #31
     global sizes = ( (5, 2), (3, 3), (3, 2), (2, 2), (9, 2), (7, 1) )
     N = length(sizes) - 1

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -73,6 +73,8 @@ using Test, LinearMaps, LinearAlgebra
     v = randn(10)
     @test @inferred (2 * L)' * v ≈ 2 * v
     @test @inferred transpose(2 * L) * v ≈ 2 * v
+    @test @inferred (L*2)' * v ≈ 2 * v
+    @test @inferred transpose(L*2) * v ≈ 2 * v
     L = @inferred LinearMap{ComplexF64}(x -> x, x -> x, 10)
     v = rand(ComplexF64, 10)
     w = similar(v)

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -59,7 +59,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
                     mallocs = run(bmat, samples=3).allocs
                     @test lallocs <= mallocs
                     @test lallocs == 0
-                    
+
                     blmap = @benchmarkable mul!($w, $(LC + λ*I), $v, $α, $β)
                     bmat = @benchmarkable begin
                         mul!($w, $A, $v, $α, $β)

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -53,9 +53,13 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
                         mul!($w, $A, $v, $α, $β)
                         mul!($w, $B, $v, $α, true)
                     end
-                    @test run(blmap, samples=3).allocs <= run(bmat, samples=3).allocs
-                    if VERSION >= v"1.4.0-DEV.400"
-                        @test_broken run(blmap, samples=3).allocs == 0
+                    lallocs = run(blmap, samples=3).allocs
+                    mallocs = run(bmat, samples=3).allocs
+                    @test lallocs <= mallocs
+                    if length(sz) == 2 && VERSION <= v"1.4.0-DEV.400"
+                        @test_broken lallocs == 0
+                    else
+                        @test lallocs == 0
                     end
                     blmap = @benchmarkable mul!($w, $(LC + λ*I), $v, $α, $β)
                     bmat = @benchmarkable begin
@@ -63,10 +67,13 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
                         mul!($w, $B, $v, $α, true)
                         mul!($w, $(λ*I), $v, $α, true)
                     end
-                    @show α, β, λ, sz
-                    @test run(blmap, samples=3).allocs <= run(bmat, samples=3).allocs
-                    if VERSION >= v"1.4.0-DEV.400"
-                        @test_broken run(blmap, samples=3).allocs == 0
+                    lallocs = run(blmap, samples=3).allocs
+                    mallocs = run(bmat, samples=3).allocs
+                    @test lallocs <= mallocs
+                    if length(sz) == 2 && VERSION <= v"1.4.0-DEV.400"
+                        @test_broken lallocs == 0
+                    elseif length(sz) == 1
+                        @test lallocs == 0
                     end
                 end
                 y = rand(ComplexF64, sz)

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -57,7 +57,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
                     mallocs = run(bmat, samples=3).allocs
                     @test lallocs <= mallocs
                     if length(sz) == 2 && VERSION <= v"1.4.0-DEV.400"
-                        @test_broken lallocs == 0
+                        @test lallocs == 0
                     else
                         @test lallocs == 0
                     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ include("uniformscalingmap.jl")
 
 include("numbertypes.jl")
 
-include("blockmap.jl")
+# include("blockmap.jl")
 
 include("kronecker.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,7 @@ import LinearMaps: FiveArg, ThreeArg
 
 const matrixstyle = VERSION ≥ v"1.3.0-alpha.115" ? FiveArg() : ThreeArg()
 
-const testallocs = true
-
-const testallocs = false
+const testallocs = VERSION ≥ v"1.4.0-"
 
 include("linearmaps.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ const matrixstyle = VERSION ≥ v"1.3.0-alpha.115" ? FiveArg() : ThreeArg()
 
 const testallocs = true
 
+const testallocs = false
+
 include("linearmaps.jl")
 
 include("transpose.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ include("uniformscalingmap.jl")
 
 include("numbertypes.jl")
 
-# include("blockmap.jl")
+include("blockmap.jl")
 
 include("kronecker.jl")
 

--- a/test/transpose.jl
+++ b/test/transpose.jl
@@ -66,6 +66,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
     x = rand(ComplexF64, 10)
     for transform1 in (adjoint, transpose), transform2 in (adjoint, transpose)
         @test transform2(LinearMap(transform1(CS))) * x ≈ transform2(transform1(M))*x
+        @test transform2(transform1(CS)) * x ≈ transform2(transform1(M))*x
     end
 
     id = @inferred LinearMap(identity, identity, 10; issymmetric=true, ishermitian=true, isposdef=true)

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -27,8 +27,8 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     @test LinearMap(2 * M' + 0I)' * v ≈ (2 * A')' * v
     for λ in (0, 1, rand()), α in (0, 1, rand()), β in (0, 1, rand()), sz in (10, (10,5))
         Λ = @inferred LinearMap(λ*I, 10)
-        x = rand(10)
-        y = rand(10)
+        x = rand(Float64, sz)
+        y = rand(Float64, sz)
         if testallocs
             b = @benchmarkable mul!($y, $Λ, $x, $α, $β)
             @test run(b, samples=3).allocs == 0

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -25,7 +25,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     @test (3 * I - 2 * M') * v == -2 * A'v + 3v
     @test transpose(LinearMap(2 * M' + 3 * I)) * v ≈ transpose(2 * A' + 3 * I) * v
     @test LinearMap(2 * M' + 0I)' * v ≈ (2 * A')' * v
-    for λ in (0, 1, rand()), α in (0, 1, rand()), β in (0, 1, rand())
+    for λ in (0, 1, rand()), α in (0, 1, rand()), β in (0, 1, rand()), sz in (10, (10,5))
         Λ = @inferred LinearMap(λ*I, 10)
         x = rand(10)
         y = rand(10)

--- a/test/wrappedmap.jl
+++ b/test/wrappedmap.jl
@@ -1,4 +1,4 @@
-using Test, LinearMaps, LinearAlgebra
+using Test, LinearMaps, LinearAlgebra, BenchmarkTools
 
 @testset "wrapped maps" begin
     A = rand(10, 20)
@@ -14,4 +14,35 @@ using Test, LinearMaps, LinearAlgebra
     @test @inferred !issymmetric(MB)
     @test @inferred isposdef(MA)
     @test @inferred isposdef(MB)
+    B = rand(ComplexF64, 20, 20)
+    v = rand(ComplexF64, 20)
+    u = rand(ComplexF64, 20)
+    LB = LinearMap(B)
+    for α in (false, true, rand(ComplexF64)), β in (false, true, rand(ComplexF64))
+        for transform in (identity, adjoint, transpose)
+            @test mul!(copy(u), transform(LB), v, α, β) ≈ transform(B)*v*α + u*β
+            @test mul!(copy(u), transform(LinearMap(LB)), v, α, β) ≈ transform(B)*v*α + u*β
+            @test mul!(copy(u), transform(LinearMap(LinearMap(LB))), v, α, β) ≈ transform(B)*v*α + u*β
+            @test mul!(copy(u), LinearMap(transform(LinearMap(LB))), v, α, β) ≈ transform(B)*v*α + u*β
+            if testallocs
+                blmap = @benchmarkable mul!($(copy(u)), $(transform(LB)), $v, $α, $β)
+                @test run(blmap, samples=3).allocs == 0
+            end
+        end
+    end
+
+    CS! = LinearMap{ComplexF64}(cumsum!,
+                                (y, x) -> (copyto!(y, x); reverse!(y); cumsum!(y, y); reverse!(y)), 10;
+                                ismutating=true)
+    v = rand(ComplexF64, 10)
+    u = rand(ComplexF64, 10)
+    M = Matrix(CS!)
+    for α in (false, true, rand(ComplexF64)), β in (false, true, rand(ComplexF64))
+        for transform in (identity, adjoint, transpose)
+            @test mul!(copy(u), transform(CS!), v, α, β) ≈ transform(M)*v*α + u*β
+            @test mul!(copy(u), transform(LinearMap(CS!)), v, α, β) ≈ transform(M)*v*α + u*β
+            @test mul!(copy(u), transform(LinearMap(LinearMap(CS!))), v, α, β) ≈ transform(M)*v*α + u*β
+            @test mul!(copy(u), LinearMap(transform(LinearMap(CS!))), v, α, β) ≈ transform(M)*v*α + u*β
+        end
+    end
 end


### PR DESCRIPTION
This started innocently, and became a major code overhaul. I realized somewhere in #72 I guess that one can get rid of all the `A*_mul_B!` by dispatching`mul!` on things like `AdjointMap{<:Any,<:SomeLinearMap}`. This turned out to be really nice, because for subtypes of `LinearMap`s, that are invariant under transposition/adjoint, certain combinations are now impossible to obtain by standard means, even when artificially wrapping, say, a `CompositeMap` in a `LinearMap` and only then taking the tranpose/adjoint. The beauty of it is that, eventually, up to some helper functions, this package is back where at was pre-0.7, that is, provides types and function overloads for `Base` or `LinearAlgebra` functions (with `kronsum` and some symbols the only exceptions).

For review, I suggest to skip `blockmap.jl`, because that may require a rebase after #72 is merged (even though I simplified some code already).

EDIT: I forgot to mention that this also takes big steps forward in providing specialized 5-arg `mul!`s for both vectors **and** matrices.