### PR TITLE
Introduce specific show methods

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -14,6 +14,12 @@ Abstract supertype
 LinearMaps.LinearMap
 ```
 
+Unwrapping function
+
+```@docs
+Base.parent
+```
+
 ### `FunctionMap`
 
 Type for wrapping an arbitrary function that is supposed to implement the

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -235,6 +235,7 @@ include("functionmap.jl") # using a function as linear map
 include("blockmap.jl") # block linear maps
 include("kronecker.jl") # Kronecker product of linear maps
 include("conversion.jl") # conversion of linear maps to matrices
+include("show.jl") # show methods for LinearMap objects
 
 """
     LinearMap(A::LinearMap; kwargs...)::WrappedMap

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -48,6 +48,15 @@ Base.ndims(::LinearMap) = 2
 Base.size(A::LinearMap, n) = (n==1 || n==2 ? size(A)[n] : error("LinearMap objects have only 2 dimensions"))
 Base.length(A::LinearMap) = size(A)[1] * size(A)[2]
 
+"""
+    parent(A::LinearMap)
+
+Return the underlying "parent map". This parent map is what was passed as an argument to
+the specific `LinearMap` constructor, including implicit constructors and up to implicit
+promotion to a `LinearMap` subtype. The fallback is to return the input itself.
+"""
+Base.parent(A::LinearMap) = A
+
 # check dimension consistency for multiplication A*B
 _iscompatible((A, B)) = size(A, 2) == size(B, 1)
 function check_dim_mul(A, B)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -17,6 +17,8 @@ BlockMap{T}(maps::As, rows::S) where {T,As<:Tuple{Vararg{LinearMap}},S} = BlockM
 
 MulStyle(A::BlockMap) = MulStyle(A.maps...)
 
+Base.parent(A::BlockMap) = A.maps
+
 """
     rowcolranges(maps, rows)
 
@@ -457,6 +459,10 @@ object among the first 8 arguments.
 Base.cat
 
 Base.size(A::BlockDiagonalMap) = (last(A.rowranges[end]), last(A.colranges[end]))
+
+MulStyle(A::BlockDiagonalMap) = MulStyle(A.maps...)
+
+Base.parent(A::BlockDiagonalMap) = A.maps
 
 LinearAlgebra.issymmetric(A::BlockDiagonalMap) = all(issymmetric, A.maps)
 LinearAlgebra.ishermitian(A::BlockDiagonalMap{<:Real}) = all(issymmetric, A.maps)

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -17,6 +17,7 @@ CompositeMap{T}(maps::As) where {T, As<:Tuple{Vararg{LinearMap}}} = CompositeMap
 # basic methods
 Base.size(A::CompositeMap) = (size(A.maps[end], 1), size(A.maps[1], 2))
 Base.isreal(A::CompositeMap) = all(isreal, A.maps) # sufficient but not necessary
+Base.parent(A::CompositeMap) = A.maps
 
 # the following rules are sufficient but not necessary
 for (f, _f, g) in ((:issymmetric, :_issymmetric, :transpose),

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -23,6 +23,7 @@ FunctionMap{T}(f, fc, M::Int; kwargs...) where {T}     = FunctionMap{T}(f, fc, M
 
 # properties
 Base.size(A::FunctionMap) = (A.M, A.N)
+Base.parent(A::FunctionMap) = (A.f, A.fc)
 LinearAlgebra.issymmetric(A::FunctionMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::FunctionMap) = A._ishermitian
 LinearAlgebra.isposdef(A::FunctionMap)    = A._isposdef

--- a/src/functionmap.jl
+++ b/src/functionmap.jl
@@ -21,14 +21,6 @@ FunctionMap{T}(f, M::Int; kwargs...) where {T}         = FunctionMap{T}(f, nothi
 FunctionMap{T}(f, M::Int, N::Int; kwargs...) where {T} = FunctionMap{T}(f, nothing, M, N; kwargs...)
 FunctionMap{T}(f, fc, M::Int; kwargs...) where {T}     = FunctionMap{T}(f, fc, M, M; kwargs...)
 
-# show
-function Base.show(io::IO, A::FunctionMap{T, F, Nothing}) where {T, F}
-    print(io, "LinearMaps.FunctionMap{$T}($(A.f), $(A.M), $(A.N); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
-end
-function Base.show(io::IO, A::FunctionMap{T}) where {T}
-    print(io, "LinearMaps.FunctionMap{$T}($(A.f), $(A.fc), $(A.M), $(A.N); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
-end
-
 # properties
 Base.size(A::FunctionMap) = (A.M, A.N)
 LinearAlgebra.issymmetric(A::FunctionMap) = A._issymmetric

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -88,6 +88,8 @@ Base.:(^)(A::MapOrMatrix, ::KronPower{p}) where {p} =
 
 Base.size(A::KroneckerMap) = map(*, size.(A.maps)...)
 
+Base.parent(A::KroneckerMap) = A.maps
+
 LinearAlgebra.issymmetric(A::KroneckerMap) = all(issymmetric, A.maps)
 LinearAlgebra.ishermitian(A::KroneckerMap{<:Real}) = issymmetric(A)
 LinearAlgebra.ishermitian(A::KroneckerMap) = all(ishermitian, A.maps)
@@ -123,7 +125,7 @@ end
     if nb*ma < mb*na 
         _unsafe_mul!(Y, B, Matrix(X*At))
     else
-        _unsafe_mul!(Y, Matrix(B*X), At isa MatrixMap ? At.lmap : At.λ)
+        _unsafe_mul!(Y, Matrix(B*X), parent(At))
     end
     return y
 end
@@ -248,6 +250,7 @@ Base.:(^)(A::MapOrMatrix, ::KronSumPower{p}) where {p} = kronsum(ntuple(n -> con
 
 Base.size(A::KroneckerSumMap, i) = prod(size.(A.maps, i))
 Base.size(A::KroneckerSumMap) = (size(A, 1), size(A, 2))
+Base.parent(A::KroneckerSumMap) = A.maps
 
 LinearAlgebra.issymmetric(A::KroneckerSumMap) = all(issymmetric, A.maps)
 LinearAlgebra.ishermitian(A::KroneckerSumMap{<:Real}) = all(issymmetric, A.maps)

--- a/src/linearcombination.jl
+++ b/src/linearcombination.jl
@@ -18,6 +18,7 @@ MulStyle(A::LinearCombination) = MulStyle(A.maps...)
 
 # basic methods
 Base.size(A::LinearCombination) = size(A.maps[1])
+Base.parent(A::LinearCombination) = A.maps
 LinearAlgebra.issymmetric(A::LinearCombination) = all(issymmetric, A.maps) # sufficient but not necessary
 LinearAlgebra.ishermitian(A::LinearCombination) = all(ishermitian, A.maps) # sufficient but not necessary
 LinearAlgebra.isposdef(A::LinearCombination) = all(isposdef, A.maps) # sufficient but not necessary

--- a/src/scaledmap.jl
+++ b/src/scaledmap.jl
@@ -13,6 +13,7 @@ ScaledMap(λ::S, lmap::A) where {S<:RealOrComplex,A<:LinearMap} =
 
 # basic methods
 Base.size(A::ScaledMap) = size(A.lmap)
+Base.parent(A::ScaledMap) = (A.λ, A.lmap)
 Base.isreal(A::ScaledMap) = isreal(A.λ) && isreal(A.lmap)
 LinearAlgebra.issymmetric(A::ScaledMap) = issymmetric(A.lmap)
 LinearAlgebra.ishermitian(A::ScaledMap) = ishermitian(A.lmap)

--- a/src/scaledmap.jl
+++ b/src/scaledmap.jl
@@ -11,12 +11,6 @@ end
 ScaledMap(λ::S, lmap::A) where {S<:RealOrComplex,A<:LinearMap} =
     ScaledMap{Base.promote_op(*, S, eltype(lmap))}(λ, lmap)
 
-# show
-function Base.show(io::IO, A::ScaledMap{T}) where {T}
-    println(io, "LinearMaps.ScaledMap{$T}, scale = $(A.λ)")
-    show(io, A.lmap)
-end
-
 # basic methods
 Base.size(A::ScaledMap) = size(A.lmap)
 Base.isreal(A::ScaledMap) = isreal(A.λ) && isreal(A.lmap)

--- a/src/show.jl
+++ b/src/show.jl
@@ -44,12 +44,7 @@ function _show(io::IO, A::BlockDiagonalMap)
 end
 function _show(io::IO, J::UniformScalingMap)
     s = "$(J.λ)"
-    if occursin(r"\w+\s*[\+\-]\s*\w+", s)
-        s = " ($s)"
-    else
-        s = " $s"
-    end
-    print(io, "\n$s")
+    print(io, " with scaling factor: $s")
 end
 
 # helper functions

--- a/src/show.jl
+++ b/src/show.jl
@@ -20,7 +20,7 @@ function _show(io::IO, A::Union{CompositeMap,LinearCombination,KroneckerMap,Kron
     print_maps(io, A.maps)
 end
 function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap})
-    println(io, " of")
+    print(io, " of ")
     L = A.lmap
     if A isa MatrixMap
         # summary(io, L)
@@ -68,11 +68,11 @@ function print_maps(io::IO, maps::Tuple{Vararg{LinearMap}})
             for i in s
                 # print(io, ' ')
                 show(io, maps[i])
+                println(io, "")
             end
-            println(io, "⋮")
+            print(io, "⋮")
             for i in e
                 println(io, "")
-                # print(io, ' ')
                 show(io, maps[i])
             end
         else

--- a/src/show.jl
+++ b/src/show.jl
@@ -7,6 +7,7 @@ end
 
 # show
 Base.show(io::IO, A::LinearMap) = (summary(io, A); _show(io, A))
+_show(io::IO, ::LinearMap) = nothing
 function _show(io::IO, A::FunctionMap{T,F,Nothing}) where {T,F}
     print(io, "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -25,9 +25,10 @@ function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap})
     if A isa MatrixMap
         # summary(io, L)
         # println(io, ":")
-        Base.print_matrix(io, L)
+        # Base.print_matrix(io, L)
+        print(io, typeof(L))
     else
-        _show(io, L)
+        show(io, L)
     end
 end
 function _show(io::IO, A::BlockMap)
@@ -37,7 +38,6 @@ function _show(io::IO, A::BlockMap)
     print_maps(io, A.maps)
 end
 function _show(io::IO, A::BlockDiagonalMap)
-    nrows = length(A.rows)
     n = length(A.maps)
     println(io, " with $n diagonal block map", n>1 ? "s" : "")
     print_maps(io, A.maps)
@@ -45,6 +45,10 @@ end
 function _show(io::IO, J::UniformScalingMap)
     s = "$(J.λ)"
     print(io, " with scaling factor: $s")
+end
+function _show(io::IO, A::ScaledMap{T}) where {T}
+    println(io, " with scale: $(A.λ) of")
+    show(io, A.lmap)
 end
 
 # helper functions

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,96 @@
+# summary
+function Base.summary(io::IO, A::LinearMap)
+    print(io, Base.dims2string(size(A)))
+    print(io, ' ')
+    _show_typeof(io, A)
+end
+
+# show
+Base.show(io::IO, A::LinearMap) = (summary(io, A); _show(io, A))
+function _show(io::IO, A::FunctionMap{T,F,Nothing}) where {T,F}
+    print(io, "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
+end
+function _show(io::IO, A::FunctionMap)
+    print(io, "($(A.f), $(A.fc); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
+end
+function _show(io::IO, A::Union{CompositeMap,LinearCombination,KroneckerMap,KroneckerSumMap})
+    n = length(A.maps)
+    println(io, " with $n map", n>1 ? "s" : "", ":")
+    print_maps(io, A.maps)
+end
+function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap})
+    println(io, " of")
+    L = A.lmap
+    if A isa MatrixMap
+        # summary(io, L)
+        # println(io, ":")
+        Base.print_matrix(io, L)
+    else
+        _show(io, L)
+    end
+end
+function _show(io::IO, A::BlockMap)
+    nrows = length(A.rows)
+    n = length(A.maps)
+    println(io, " with $n block map", n>1 ? "s" : "", " in $nrows block row", nrows>1 ? "s" : "")
+    print_maps(io, A.maps)
+end
+function _show(io::IO, A::BlockDiagonalMap)
+    nrows = length(A.rows)
+    n = length(A.maps)
+    println(io, " with $n diagonal block map", n>1 ? "s" : "")
+    print_maps(io, A.maps)
+end
+function _show(io::IO, J::UniformScalingMap)
+    s = "$(J.λ)"
+    if occursin(r"\w+\s*[\+\-]\s*\w+", s)
+        s = " ($s)"
+    else
+        s = " $s"
+    end
+    print(io, "\n$s")
+end
+
+# helper functions
+function _show_typeof(io::IO, A::LinearMap{T}) where {T}
+    Base.show_type_name(io, typeof(A).name)
+    print(io, '{')
+    show(io, T)
+    print(io, '}')
+end
+
+function print_maps(io::IO, maps::Tuple{Vararg{LinearMap}})
+    n = length(maps)
+    if get(io, :limit, true) && n > 10
+        s = 1:5
+        e = n-5:n
+        if e[1] - s[end] > 1
+            for i in s
+                # print(io, ' ')
+                show(io, maps[i])
+            end
+            println(io, "⋮")
+            for i in e
+                println(io, "")
+                # print(io, ' ')
+                show(io, maps[i])
+            end
+        else
+            for i in 1:n-1
+                # print(io, ' ')
+                show(io, maps[i])
+                println(io, "")
+            end
+            # print(io, ' ')
+            show(io, last(maps))
+        end
+    else
+        for i in 1:n-1
+            # print(io, ' ')
+            show(io, maps[i])
+            println(io, "")
+        end
+        # print(io, ' ')
+        show(io, last(maps))
+    end
+end

--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -11,6 +11,8 @@ MulStyle(A::Union{TransposeMap,AdjointMap}) = MulStyle(A.lmap)
 LinearAlgebra.transpose(A::TransposeMap) = A.lmap
 LinearAlgebra.adjoint(A::AdjointMap) = A.lmap
 
+Base.parent(A::Union{AdjointMap,TransposeMap}) = A.lmap
+
 """
     transpose(A::LinearMap)
 

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -15,6 +15,7 @@ MulStyle(::UniformScalingMap) = FiveArg()
 
 # properties
 Base.size(A::UniformScalingMap) = (A.M, A.M)
+Base.parent(A::UniformScalingMap) = A.λ
 Base.isreal(A::UniformScalingMap) = isreal(A.λ)
 LinearAlgebra.issymmetric(::UniformScalingMap) = true
 LinearAlgebra.ishermitian(A::UniformScalingMap) = isreal(A)

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -32,6 +32,7 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) =
 
 # properties
 Base.size(A::WrappedMap) = size(A.lmap)
+Base.parent(A::WrappedMap) = A.lmap
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian
 LinearAlgebra.isposdef(A::WrappedMap) = A._isposdef

--- a/test/blockmap.jl
+++ b/test/blockmap.jl
@@ -7,6 +7,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             A12 = rand(elty, 10, n2)
             v = rand(elty, 10)
             L = @inferred hcat(LinearMap(A11), LinearMap(A12))
+            @test occursin("10×$(10+n2) LinearMaps.BlockMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), L))
             @test @inferred(LinearMaps.MulStyle(L)) === matrixstyle
             @test L isa LinearMaps.BlockMap{elty}
             if elty <: Complex
@@ -45,6 +46,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             @test Matrix(L) ≈ A11
             A21 = rand(elty, 20, 10)
             L = @inferred vcat(LinearMap(A11), LinearMap(A21))
+            @test occursin("30×10 LinearMaps.BlockMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), L))
             @test L isa LinearMaps.BlockMap{elty}
             @test @inferred(LinearMaps.MulStyle(L)) === matrixstyle
             @test (@which [A11; A21]).module != LinearMaps
@@ -193,6 +195,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             @test (@which cat(M1, M2, M3, M2, M1; dims=(1,2))).module != LinearMaps
             x = randn(elty, size(Md, 2))
             Bd = @inferred blockdiag(L1, L2, L3, L2, L1)
+            @test occursin("25×39 LinearMaps.BlockDiagonalMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), Bd))
             @test Matrix(Bd) == Md
             @test convert(AbstractMatrix, Bd) isa SparseMatrixCSC
             @test sparse(Bd) == Md

--- a/test/blockmap.jl
+++ b/test/blockmap.jl
@@ -7,6 +7,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             A12 = rand(elty, 10, n2)
             v = rand(elty, 10)
             L = @inferred hcat(LinearMap(A11), LinearMap(A12))
+            @test parent(L) == (LinearMap(A11), LinearMap(A12))
             @test occursin("10×$(10+n2) LinearMaps.BlockMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), L))
             @test @inferred(LinearMaps.MulStyle(L)) === matrixstyle
             @test L isa LinearMaps.BlockMap{elty}
@@ -31,6 +32,10 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             x = rand(elty, 61)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x
+            L = @inferred hcat(I, I, I, LinearMap(A11), A11, A11, v, v, v, v)
+            @test occursin("10×64 LinearMaps.BlockMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), L))
+            L = @inferred hcat(I, I, I, LinearMap(A11), A11, A11, v, v, v, v, v, v, v)
+            @test occursin("10×67 LinearMaps.BlockMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), L))
             A11 = rand(elty, 11, 10)
             A12 = rand(elty, 10, n2)
             @test_throws DimensionMismatch hcat(LinearMap(A11), LinearMap(A12))
@@ -195,6 +200,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             @test (@which cat(M1, M2, M3, M2, M1; dims=(1,2))).module != LinearMaps
             x = randn(elty, size(Md, 2))
             Bd = @inferred blockdiag(L1, L2, L3, L2, L1)
+            @test parent(Bd) == (L1, L2, L3, L2, L1)
             @test occursin("25×39 LinearMaps.BlockDiagonalMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), Bd))
             @test Matrix(Bd) == Md
             @test convert(AbstractMatrix, Bd) isa SparseMatrixCSC

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -20,6 +20,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
     @test @inferred (A * F) * v == @inferred A * (F * v)
     @test @inferred A * (F * F) * v == @inferred A * (F * (F * v))
     F2 = F*F
+    @test parent(F2) == (F, F)
     FC2 = FC*FC
     F4 = FC2 * F2
     @test occursin("10×10 LinearMaps.CompositeMap{$(eltype(F4))}", sprint((t, s) -> show(t, "text/plain", s), F4))

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -22,6 +22,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
     F2 = F*F
     FC2 = FC*FC
     F4 = FC2 * F2
+    @test occursin("10×10 LinearMaps.CompositeMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), F4))
     @test length(F4.maps) == 4
     @test @inferred F4 * v == @inferred F * (F * (F * (F * v)))
     @test @inferred Matrix(M * transpose(M)) ≈ A * transpose(A)

--- a/test/composition.jl
+++ b/test/composition.jl
@@ -22,7 +22,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
     F2 = F*F
     FC2 = FC*FC
     F4 = FC2 * F2
-    @test occursin("10×10 LinearMaps.CompositeMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), F4))
+    @test occursin("10×10 LinearMaps.CompositeMap{$(eltype(F4))}", sprint((t, s) -> show(t, "text/plain", s), F4))
     @test length(F4.maps) == 4
     @test @inferred F4 * v == @inferred F * (F * (F * (F * v)))
     @test @inferred Matrix(M * transpose(M)) ≈ A * transpose(A)

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -17,7 +17,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     MyFT = @inferred LinearMap{ComplexF64}(myft, N) / sqrt(N)
     U = Matrix(MyFT) # will be a unitary matrix
     @test @inferred U'U ≈ Matrix{eltype(U)}(I, N, N)
-    @test occursin("$N×$N LinearMaps.FunctionMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), MyFT))
+    @test occursin("$N×$N LinearMaps.FunctionMap{$(eltype(MyFT))}", sprint((t, s) -> show(t, "text/plain", s), MyFT))
 
     CS = @inferred LinearMap(cumsum, 2)
     @test size(CS) == (2, 2)

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -18,6 +18,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     U = Matrix(MyFT) # will be a unitary matrix
     @test @inferred U'U ≈ Matrix{eltype(U)}(I, N, N)
     @test occursin("$N×$N LinearMaps.FunctionMap{$(eltype(MyFT))}", sprint((t, s) -> show(t, "text/plain", s), MyFT))
+    @test parent(LinearMap{ComplexF64}(myft, N)) === (myft, nothing)
 
     CS = @inferred LinearMap(cumsum, 2)
     @test size(CS) == (2, 2)

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -17,6 +17,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     MyFT = @inferred LinearMap{ComplexF64}(myft, N) / sqrt(N)
     U = Matrix(MyFT) # will be a unitary matrix
     @test @inferred U'U ≈ Matrix{eltype(U)}(I, N, N)
+    @test occursin("$N×$N LinearMaps.FunctionMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), MyFT))
 
     CS = @inferred LinearMap(cumsum, 2)
     @test size(CS) == (2, 2)
@@ -33,6 +34,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     @test *(CS, v) == cv
     @test_throws ErrorException CS' * v
     CS = @inferred LinearMap(cumsum, x -> reverse(cumsum(reverse(x))), 10; ismutating=false)
+    @test occursin("10×10 LinearMaps.FunctionMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), CS))
     cv = cumsum(v)
     @test @inferred CS * v == cv
     @test @inferred *(CS, v) == cv

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -8,6 +8,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         LA = LinearMap(A)
         LB = LinearMap(B)
         LK = @inferred kron(LA, LB)
+        @test parent(LK) == (LA, LB)
         @test_throws AssertionError LinearMaps.KroneckerMap{Float64}((LA, LB))
         @test occursin("6×6 LinearMaps.KroneckerMap{$(eltype(LK))}", sprint((t, s) -> show(t, "text/plain", s), LK))
         @test @inferred size(LK) == size(K)
@@ -69,6 +70,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
             LA = LinearMap(A)
             LB = LinearMap(B)
             KS = @inferred kronsum(LA, B)
+            @test parent(KS) == (LA, LB)
             @test occursin("6×6 LinearMaps.KroneckerSumMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), KS))
             @test_throws ArgumentError kronsum(LA, [B B]) # non-square map
             KSmat = kron(A, Matrix(I, 2, 2)) + kron(Matrix(I, 3, 3), B)

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -9,6 +9,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         LB = LinearMap(B)
         LK = @inferred kron(LA, LB)
         @test_throws AssertionError LinearMaps.KroneckerMap{Float64}((LA, LB))
+        @test occursin("6×6 LinearMaps.KroneckerMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), LK))
         @test @inferred size(LK) == size(K)
         @test LinearMaps.MulStyle(LK) === LinearMaps.ThreeArg()
         for i in (1, 2)
@@ -68,6 +69,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
             LA = LinearMap(A)
             LB = LinearMap(B)
             KS = @inferred kronsum(LA, B)
+            @test occursin("6×6 LinearMaps.KroneckerSumMap{$elty}", sprint((t, s) -> show(t, "text/plain", s), KS))
             @test_throws ArgumentError kronsum(LA, [B B]) # non-square map
             KSmat = kron(A, Matrix(I, 2, 2)) + kron(Matrix(I, 3, 3), B)
             @test Matrix(KS) ≈ Matrix(kron(A, LinearMap(I, 2)) + kron(LinearMap(I, 3), B))

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -9,7 +9,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         LB = LinearMap(B)
         LK = @inferred kron(LA, LB)
         @test_throws AssertionError LinearMaps.KroneckerMap{Float64}((LA, LB))
-        @test occursin("6×6 LinearMaps.KroneckerMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), LK))
+        @test occursin("6×6 LinearMaps.KroneckerMap{$(eltype(LK))}", sprint((t, s) -> show(t, "text/plain", s), LK))
         @test @inferred size(LK) == size(K)
         @test LinearMaps.MulStyle(LK) === LinearMaps.ThreeArg()
         for i in (1, 2)

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -11,7 +11,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     n = 10
     L = sum(fill(CS!, n))
     @test_throws AssertionError LinearMaps.LinearCombination{Float64}((CS!, CS!))
-    @test occursin("10×10 LinearMaps.LinearCombination{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), L))
+    @test occursin("10×10 LinearMaps.LinearCombination{$(eltype(L))}", sprint((t, s) -> show(t, "text/plain", s), L))
     @test mul!(u, L, v) ≈ n * cumsum(v)
     b = @benchmarkable mul!($u, $L, $v, 2, 2)
     @test run(b, samples=5).allocs <= 1

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -11,6 +11,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     n = 10
     L = sum(fill(CS!, n))
     @test_throws AssertionError LinearMaps.LinearCombination{Float64}((CS!, CS!))
+    @test occursin("10×10 LinearMaps.LinearCombination{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), L))
     @test mul!(u, L, v) ≈ n * cumsum(v)
     b = @benchmarkable mul!($u, $L, $v, 2, 2)
     @test run(b, samples=5).allocs <= 1

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -12,6 +12,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     L = sum(fill(CS!, n))
     @test_throws AssertionError LinearMaps.LinearCombination{Float64}((CS!, CS!))
     @test occursin("10×10 LinearMaps.LinearCombination{$(eltype(L))}", sprint((t, s) -> show(t, "text/plain", s), L))
+    @test parent(L) == ntuple(_ -> CS!, 10)
     @test mul!(u, L, v) ≈ n * cumsum(v)
     b = @benchmarkable mul!($u, $L, $v, 2, 2)
     @test run(b, samples=5).allocs <= 1

--- a/test/linearmaps.jl
+++ b/test/linearmaps.jl
@@ -55,8 +55,8 @@ LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFu
     @test @inferred !ishermitian(F)
     @test @inferred !ishermitian(FC)
     @test @inferred !isposdef(F)
-    @test occursin("10×10 SimpleFunctionMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), F))
-    @test occursin("10×10 SimpleComplexFunctionMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), FC))
+    @test occursin("10×10 SimpleFunctionMap{$(eltype(F))}", sprint((t, s) -> show(t, "text/plain", s), F))
+    @test occursin("10×10 SimpleComplexFunctionMap{$(eltype(FC))}", sprint((t, s) -> show(t, "text/plain", s), FC))
     α = rand(ComplexF64); β = rand(ComplexF64)
     v = rand(ComplexF64, 10); V = rand(ComplexF64, 10, 3)
     w = rand(ComplexF64, 10); W = rand(ComplexF64, 10, 3)
@@ -71,8 +71,10 @@ LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFu
     @test F * v ≈ L * v
     # generic 5-arg mul! and matrix-mul!
     @test mul!(copy(w), F, v, α, β) ≈ L*v*α + w*β
+    @test mul!(copy(w), F, v, 0, β) ≈ w*β
     @test mul!(copy(W), F, V) ≈ L*V
     @test mul!(copy(W), F, V, α, β) ≈ L*V*α + W*β
+    @test mul!(copy(W), F, V, 0, β) ≈ W*β
 
     Fs = sparse(F)
     @test SparseMatrixCSC(F) == Fs == L

--- a/test/linearmaps.jl
+++ b/test/linearmaps.jl
@@ -21,34 +21,6 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools
         @test length(M) == length(A)
     end
 
-    Av = A * v
-    AV = A * V
-
-    @testset "mul! and *" begin
-        for w in (vec(u), u)
-            @test M * v == Av
-            @test N * v == Av
-            @test @inferred mul!(copy(w), M, v) == mul!(copy(w), A, v)
-            b = @benchmarkable mul!($w, $M, $v)
-            @test run(b, samples=3).allocs == 0
-            @test @inferred mul!(copy(w), N, v) == mul!(copy(w), A, v)
-
-            # mat-vec-mul
-            @test @inferred mul!(copy(w), M, v, 0, 0) == zero(w)
-            @test @inferred mul!(copy(w), M, v, 0, 1) == w
-            @test @inferred mul!(copy(w), M, v, 0, β) == β * w
-            @test @inferred mul!(copy(w), M, v, 1, 1) ≈ Av + w
-            @test @inferred mul!(copy(w), M, v, 1, β) ≈ Av + β * w
-            @test @inferred mul!(copy(w), M, v, α, 1) ≈ α * Av + w
-            @test @inferred mul!(copy(w), M, v, α, β) ≈ α * Av + β * w
-        end
-
-        # test mat-mat-mul!
-        @test @inferred mul!(copy(W), M, V, α, β) ≈ α * AV + β * W
-        @test @inferred mul!(copy(W), M, V) ≈ AV
-        @test typeof(M * V) <: LinearMap
-    end
-    
     @testset "dimension checking" begin
         w = vec(u)
         @test_throws DimensionMismatch M * similar(v, length(v) + 1)
@@ -70,7 +42,7 @@ struct SimpleComplexFunctionMap <: LinearMap{Complex{Float64}}
     N::Int
 end
 Base.size(A::Union{SimpleFunctionMap,SimpleComplexFunctionMap}) = (A.N, A.N)
-Base.:(*)(A::Union{SimpleFunctionMap,SimpleComplexFunctionMap}, v::Vector) = A.f(v)
+Base.:(*)(A::Union{SimpleFunctionMap,SimpleComplexFunctionMap}, v::AbstractVector) = A.f(v)
 LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFunctionMap}, x::AbstractVector) = copyto!(y, *(A, x))
 
 @testset "new LinearMap type" begin
@@ -83,10 +55,12 @@ LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFu
     @test @inferred !ishermitian(F)
     @test @inferred !ishermitian(FC)
     @test @inferred !isposdef(F)
-    v = rand(ComplexF64, 10)
-    w = similar(v)
-    mul!(w, F, v)
-    @test w == F * v
+    @test occursin("10×10 SimpleFunctionMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), F))
+    @test occursin("10×10 SimpleComplexFunctionMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), FC))
+    α = rand(ComplexF64); β = rand(ComplexF64)
+    v = rand(ComplexF64, 10); V = rand(ComplexF64, 10, 3)
+    w = rand(ComplexF64, 10); W = rand(ComplexF64, 10, 3)
+    @test mul!(w, F, v) === w == F * v
     @test_throws ErrorException F' * v
     @test_throws ErrorException transpose(F) * v
     @test_throws ErrorException mul!(w, adjoint(FC), v)
@@ -95,6 +69,11 @@ LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFu
     L = LowerTriangular(ones(10, 10))
     @test FM == L
     @test F * v ≈ L * v
+    # generic 5-arg mul! and matrix-mul!
+    @test mul!(copy(w), F, v, α, β) ≈ L*v*α + w*β
+    @test mul!(copy(W), F, V) ≈ L*V
+    @test mul!(copy(W), F, V, α, β) ≈ L*V*α + W*β
+
     Fs = sparse(F)
     @test SparseMatrixCSC(F) == Fs == L
     @test Fs isa SparseMatrixCSC

--- a/test/linearmaps.jl
+++ b/test/linearmaps.jl
@@ -47,6 +47,7 @@ LinearAlgebra.mul!(y::AbstractVector, A::Union{SimpleFunctionMap,SimpleComplexFu
 
 @testset "new LinearMap type" begin
     F = SimpleFunctionMap(cumsum, 10)
+    @test parent(F) === F
     FC = SimpleComplexFunctionMap(cumsum, 10)
     @test @inferred ndims(F) == 2
     @test @inferred size(F, 1) == 10

--- a/test/scaledmap.jl
+++ b/test/scaledmap.jl
@@ -9,6 +9,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     α = float(π)
     B = @inferred α * A
     @test occursin("7×7 LinearMaps.ScaledMap{Float64} with scale: $α", sprint((t, s) -> show(t, "text/plain", s), B))
+    @test parent(B) == (α, A)
     x = rand(N)
 
     @test @inferred size(B) == size(A)

--- a/test/scaledmap.jl
+++ b/test/scaledmap.jl
@@ -8,6 +8,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     # real case
     α = float(π)
     B = @inferred α * A
+    @test occursin("7×7 LinearMaps.ScaledMap{Float64} with scale: $α", sprint((t, s) -> show(t, "text/plain", s), B))
     x = rand(N)
 
     @test @inferred size(B) == size(A)

--- a/test/transpose.jl
+++ b/test/transpose.jl
@@ -10,6 +10,8 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
     end
     @test occursin("10×10 LinearMaps.TransposeMap{$(eltype(CS))}", sprint((t, s) -> show(t, "text/plain", s), transpose(CS)))
     @test occursin("10×10 LinearMaps.AdjointMap{$(eltype(CS))}", sprint((t, s) -> show(t, "text/plain", s), adjoint(CS)))
+    @test parent(transpose(CS)) === CS
+    @test parent(adjoint(CS)) === CS
     @test !(transpose(CS) == adjoint(CS))
     @test !(adjoint(CS) == transpose(CS))
     M = Matrix(CS)

--- a/test/transpose.jl
+++ b/test/transpose.jl
@@ -1,59 +1,6 @@
 using Test, LinearMaps, LinearAlgebra, SparseArrays
 
 @testset "transpose/adjoint" begin
-    A = 2 * rand(ComplexF64, (20, 10)) .- 1
-    v = rand(ComplexF64, 10)
-    w = rand(ComplexF64, 20)
-    V = rand(ComplexF64, 10, 3)
-    W = rand(ComplexF64, 20, 3)
-    Av = A * v
-    AV = A * V
-    M = @inferred LinearMap(A)
-    N = @inferred LinearMap(M)
-
-    @test @inferred M' * w == A' * w
-    @test @inferred mul!(copy(V), adjoint(M), W) ≈ A' * W
-    @test @inferred transpose(M) * w == transpose(A) * w
-    @test @inferred transpose(LinearMap(transpose(M))) * v == A * v
-    @test @inferred LinearMap(M')' * v == A * v
-    @test @inferred(transpose(transpose(M))) === M
-    @test @inferred(adjoint(adjoint(M))) === M
-    Mherm = @inferred LinearMap(A'A)
-    @test @inferred ishermitian(Mherm)
-    @test @inferred !issymmetric(Mherm)
-    @test @inferred !issymmetric(transpose(Mherm))
-    @test @inferred ishermitian(transpose(Mherm))
-    @test @inferred ishermitian(Mherm')
-    @test @inferred isposdef(Mherm)
-    @test @inferred isposdef(transpose(Mherm))
-    @test @inferred isposdef(adjoint(Mherm))
-    @test @inferred !(transpose(M) == adjoint(M))
-    @test @inferred !(adjoint(M) == transpose(M))
-    @test @inferred transpose(M') * v ≈ transpose(A') * v
-    @test @inferred transpose(LinearMap(M')) * v ≈ transpose(A') * v
-    @test @inferred LinearMap(transpose(M))' * v ≈ transpose(A)' * v
-    @test @inferred transpose(LinearMap(transpose(M))) * v ≈ Av
-    @test @inferred adjoint(LinearMap(adjoint(M))) * v ≈ Av
-
-    @test @inferred mul!(copy(w), transpose(LinearMap(M')), v) ≈ transpose(A') * v
-    @test @inferred mul!(copy(w), LinearMap(transpose(M))', v) ≈ transpose(A)' * v
-    @test @inferred mul!(copy(w), transpose(LinearMap(transpose(M))), v) ≈ Av
-    @test @inferred mul!(copy(w), adjoint(LinearMap(adjoint(M))), v) ≈ Av
-    @test @inferred mul!(copy(W), transpose(LinearMap(M')), V) ≈ transpose(A') * V
-    @test @inferred mul!(copy(W), LinearMap(transpose(M))', V) ≈ transpose(A)' * V
-    @test @inferred mul!(copy(W), transpose(LinearMap(transpose(M))), V) ≈ AV
-    @test @inferred mul!(copy(W), adjoint(LinearMap(adjoint(M))), V) ≈ AV
-    @test @inferred mul!(copy(V), transpose(M), W) ≈ transpose(A) * W
-    @test @inferred mul!(copy(V), adjoint(M), W) ≈ A' * W
-
-    B = @inferred LinearMap(Symmetric(rand(10, 10)))
-    @test transpose(B) == B
-    @test B == transpose(B)
-
-    B = @inferred LinearMap(Hermitian(rand(ComplexF64, 10, 10)))
-    @test adjoint(B) == B
-    @test B == B'
-
     CS = @inferred LinearMap{ComplexF64}(cumsum, x -> reverse(cumsum(reverse(x))), 10; ismutating=false)
     for transform in (adjoint, transpose)
         @test transform(CS) != CS
@@ -61,6 +8,8 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         @test transform(transform(CS)) == CS
         @test LinearMaps.MulStyle(transform(CS)) === LinearMaps.MulStyle(CS)
     end
+    @test occursin("10×10 LinearMaps.TransposeMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), transpose(CS)))
+    @test occursin("10×10 LinearMaps.AdjointMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), adjoint(CS)))
     @test !(transpose(CS) == adjoint(CS))
     @test !(adjoint(CS) == transpose(CS))
     M = Matrix(CS)

--- a/test/transpose.jl
+++ b/test/transpose.jl
@@ -8,8 +8,8 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         @test transform(transform(CS)) == CS
         @test LinearMaps.MulStyle(transform(CS)) === LinearMaps.MulStyle(CS)
     end
-    @test occursin("10×10 LinearMaps.TransposeMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), transpose(CS)))
-    @test occursin("10×10 LinearMaps.AdjointMap{Complex{Float64}}", sprint((t, s) -> show(t, "text/plain", s), adjoint(CS)))
+    @test occursin("10×10 LinearMaps.TransposeMap{$(eltype(CS))}", sprint((t, s) -> show(t, "text/plain", s), transpose(CS)))
+    @test occursin("10×10 LinearMaps.AdjointMap{$(eltype(CS))}", sprint((t, s) -> show(t, "text/plain", s), adjoint(CS)))
     @test !(transpose(CS) == adjoint(CS))
     @test !(adjoint(CS) == transpose(CS))
     M = Matrix(CS)

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -11,6 +11,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     w = similar(v)
     Id = @inferred LinearMap(I, 10)
     @test occursin("10×10 LinearMaps.UniformScalingMap{Bool}", sprint((t, s) -> show(t, "text/plain", s), Id))
+    @test parent(Id) == true
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, 10, 20)
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, (10, 20))
     @test size(Id) == (10, 10)

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -10,6 +10,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     v = rand(ComplexF64, 10)
     w = similar(v)
     Id = @inferred LinearMap(I, 10)
+    @test occursin("10×10 LinearMaps.UniformScalingMap{Bool}", sprint((t, s) -> show(t, "text/plain", s), Id))
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, 10, 20)
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, (10, 20))
     @test size(Id) == (10, 10)

--- a/test/wrappedmap.jl
+++ b/test/wrappedmap.jl
@@ -6,6 +6,7 @@ using Test, LinearMaps, LinearAlgebra
     SA = A'A + I
     SB = B'B + I
     L = @inferred LinearMap{Float64}(A)
+    @test occursin("10×20 LinearMaps.WrappedMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), L))
     MA = @inferred LinearMap(SA)
     MB = @inferred LinearMap(SB)
     @test eltype(Matrix{Complex{Float32}}(LinearMap(A))) <: Complex
@@ -15,4 +16,60 @@ using Test, LinearMaps, LinearAlgebra
     @test @inferred !issymmetric(MB)
     @test @inferred isposdef(MA)
     @test @inferred isposdef(MB)
+
+    A = 2 * rand(ComplexF64, (20, 10)) .- 1
+    v = rand(ComplexF64, 10)
+    w = rand(ComplexF64, 20)
+    u = rand(ComplexF64, 20, 1)
+    V = rand(ComplexF64, 10, 3)
+    W = rand(ComplexF64, 20, 3)
+    Av = A * v
+    AV = A * V
+    M = @inferred LinearMap(A)
+    N = @inferred LinearMap(M)
+
+    @test @inferred M' * w == A' * w
+    @test @inferred mul!(copy(V), adjoint(M), W) ≈ A' * W
+    @test @inferred transpose(M) * w == transpose(A) * w
+    @test @inferred transpose(LinearMap(transpose(M))) * v == A * v
+    @test @inferred LinearMap(M')' * v == A * v
+    @test @inferred(transpose(transpose(M))) === M
+    @test @inferred(adjoint(adjoint(M))) === M
+    Mherm = @inferred LinearMap(A'A)
+    @test @inferred ishermitian(Mherm)
+    @test @inferred !issymmetric(Mherm)
+    @test @inferred !issymmetric(transpose(Mherm))
+    @test @inferred ishermitian(transpose(Mherm))
+    @test @inferred ishermitian(Mherm')
+    @test @inferred isposdef(Mherm)
+    @test @inferred isposdef(transpose(Mherm))
+    @test @inferred isposdef(adjoint(Mherm))
+    @test @inferred !(transpose(M) == adjoint(M))
+    @test @inferred !(adjoint(M) == transpose(M))
+    @test @inferred transpose(M') * v ≈ transpose(A') * v
+    @test @inferred transpose(LinearMap(M')) * v ≈ transpose(A') * v
+    @test @inferred LinearMap(transpose(M))' * v ≈ transpose(A)' * v
+    @test @inferred transpose(LinearMap(transpose(M))) * v ≈ Av
+    @test @inferred adjoint(LinearMap(adjoint(M))) * v ≈ Av
+
+    for w in (vec(u), u)
+        @test @inferred mul!(copy(w), transpose(LinearMap(M')), v) ≈ transpose(A') * v
+        @test @inferred mul!(copy(w), LinearMap(transpose(M))', v) ≈ transpose(A)' * v
+        @test @inferred mul!(copy(w), transpose(LinearMap(transpose(M))), v) ≈ Av
+        @test @inferred mul!(copy(w), adjoint(LinearMap(adjoint(M))), v) ≈ Av
+    end
+    @test @inferred mul!(copy(W), transpose(LinearMap(M')), V) ≈ transpose(A') * V
+    @test @inferred mul!(copy(W), LinearMap(transpose(M))', V) ≈ transpose(A)' * V
+    @test @inferred mul!(copy(W), transpose(LinearMap(transpose(M))), V) ≈ AV
+    @test @inferred mul!(copy(W), adjoint(LinearMap(adjoint(M))), V) ≈ AV
+    @test @inferred mul!(copy(V), transpose(M), W) ≈ transpose(A) * W
+    @test @inferred mul!(copy(V), adjoint(M), W) ≈ A' * W
+
+    B = @inferred LinearMap(Symmetric(rand(10, 10)))
+    @test transpose(B) == B
+    @test B == transpose(B)
+
+    B = @inferred LinearMap(Hermitian(rand(ComplexF64, 10, 10)))
+    @test adjoint(B) == B
+    @test B == B'
 end

--- a/test/wrappedmap.jl
+++ b/test/wrappedmap.jl
@@ -7,6 +7,7 @@ using Test, LinearMaps, LinearAlgebra
     SB = B'B + I
     L = @inferred LinearMap{Float64}(A)
     @test occursin("10×20 LinearMaps.WrappedMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), L))
+    @test parent(L) === A
     MA = @inferred LinearMap(SA)
     MB = @inferred LinearMap(SB)
     @test eltype(Matrix{Complex{Float32}}(LinearMap(A))) <: Complex


### PR DESCRIPTION
I was very inspired by the `show` methods in #84, so I went ahead and introduced consistent such methods for all `LinearMap` subtypes. This is the current output:
```julia
julia> using LinearAlgebra, LinearMaps

julia> A = LinearMap(rand(10, 10))
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222   0.036539631768852665  …  0.9873418166811534
 0.6765549649256377   0.9624717119719399       0.3575343347655404
 0.31545830565381205  0.846611890984601        0.07509443800525162
 0.9046438881682486   0.6282119777830519       0.16271650036125607
 0.13027892373965533  0.18887153454128924      0.3656173314780382
 0.8105579896722099   0.8689278012808201    …  0.613575621252296
 0.3501936207693894   0.41662154485059477      0.634150209365973
 0.5371570288242542   0.7182968669111338       0.3200262911743803
 0.9126028660250189   0.25564178492353906      0.23743297526797136
 0.5819814278543964   0.9943728715581492       0.4875339524077975

julia> B = LinearMap(rand(10, 10))
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719     0.458876698914481    …  0.21599839571588952
 0.5444272069489469     0.30974679189517595     0.20158982970939365
 0.0039023841368437395  0.1743141153244383      0.5255090943219167
 0.6585137742811065     0.21529067784534073     0.09553647923800157
 0.6810489351017359     0.7726713554570053      0.88655004487403
 0.02948775918770319    0.804402117644776    …  0.8520117918594712
 0.981317366746389      0.42937017270368405     0.723298669979153
 0.05590009791874673    0.23243683344460941     0.7504218236329141
 0.6105003794996771     0.23372276641277856     0.5026331262236272
 0.45419955654642186    0.9829667847054768      0.5560613057463222

julia> A + B
10×10 LinearMaps.LinearCombination{Float64} with 2 maps:
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222   0.036539631768852665  …  0.9873418166811534
 0.6765549649256377   0.9624717119719399       0.3575343347655404
 0.31545830565381205  0.846611890984601        0.07509443800525162
 0.9046438881682486   0.6282119777830519       0.16271650036125607
 0.13027892373965533  0.18887153454128924      0.3656173314780382
 0.8105579896722099   0.8689278012808201    …  0.613575621252296
 0.3501936207693894   0.41662154485059477      0.634150209365973
 0.5371570288242542   0.7182968669111338       0.3200262911743803
 0.9126028660250189   0.25564178492353906      0.23743297526797136
 0.5819814278543964   0.9943728715581492       0.4875339524077975
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719     0.458876698914481    …  0.21599839571588952
 0.5444272069489469     0.30974679189517595     0.20158982970939365
 0.0039023841368437395  0.1743141153244383      0.5255090943219167
 0.6585137742811065     0.21529067784534073     0.09553647923800157
 0.6810489351017359     0.7726713554570053      0.88655004487403
 0.02948775918770319    0.804402117644776    …  0.8520117918594712
 0.981317366746389      0.42937017270368405     0.723298669979153
 0.05590009791874673    0.23243683344460941     0.7504218236329141
 0.6105003794996771     0.23372276641277856     0.5026331262236272
 0.45419955654642186    0.9829667847054768      0.5560613057463222

julia> A*B
10×10 LinearMaps.CompositeMap{Float64} with 2 maps:
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719     0.458876698914481    …  0.21599839571588952
 0.5444272069489469     0.30974679189517595     0.20158982970939365
 0.0039023841368437395  0.1743141153244383      0.5255090943219167
 0.6585137742811065     0.21529067784534073     0.09553647923800157
 0.6810489351017359     0.7726713554570053      0.88655004487403
 0.02948775918770319    0.804402117644776    …  0.8520117918594712
 0.981317366746389      0.42937017270368405     0.723298669979153
 0.05590009791874673    0.23243683344460941     0.7504218236329141
 0.6105003794996771     0.23372276641277856     0.5026331262236272
 0.45419955654642186    0.9829667847054768      0.5560613057463222
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222   0.036539631768852665  …  0.9873418166811534
 0.6765549649256377   0.9624717119719399       0.3575343347655404
 0.31545830565381205  0.846611890984601        0.07509443800525162
 0.9046438881682486   0.6282119777830519       0.16271650036125607
 0.13027892373965533  0.18887153454128924      0.3656173314780382
 0.8105579896722099   0.8689278012808201    …  0.613575621252296
 0.3501936207693894   0.41662154485059477      0.634150209365973
 0.5371570288242542   0.7182968669111338       0.3200262911743803
 0.9126028660250189   0.25564178492353906      0.23743297526797136
 0.5819814278543964   0.9943728715581492       0.4875339524077975

julia> A'
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222    0.6765549649256377  …  0.5819814278543964
 0.036539631768852665  0.9624717119719399     0.9943728715581492
 0.4027902717113363    0.7026369092256841     0.7617166921327674
 0.7413107404966093    0.3203641222296265     0.6735049325510956
 0.41806755601877144   0.9765426747844308     0.004982227391467697
 0.6234799174891352    0.4282253038974375  …  0.012752198200326692
 0.6776227392879477    0.5539119205793519     0.5181151045294414
 0.21409932564096135   0.9807021706390484     0.13028886265083983
 0.9115007582179364    0.2871360638798117     0.8330562268795965
 0.9873418166811534    0.3575343347655404     0.4875339524077975

julia> transpose(B)
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719   0.5444272069489469   …  0.45419955654642186
 0.458876698914481    0.30974679189517595     0.9829667847054768
 0.1941661929741807   0.8515496541558736      0.5210591620482088
 0.5049930060056573   0.9600731041579504      0.20258361820248338
 0.853244938937398    0.8770974066146568      0.3991378557794971
 0.9197564051076856   0.6721824083853565   …  0.3817926144866812
 0.24649887894680167  0.711909562164927       0.48691472563361726
 0.06738373935785602  0.4938423165045247      0.30750561352598305
 0.6377098655234006   0.6690778646165947      0.9561500428178002
 0.21599839571588952  0.20158982970939365     0.5560613057463222

julia> [A A; B B]
20×20 LinearMaps.BlockMap{Float64} with 4 block maps in 2 block rows
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222   0.036539631768852665  …  0.9873418166811534
 0.6765549649256377   0.9624717119719399       0.3575343347655404
 0.31545830565381205  0.846611890984601        0.07509443800525162
 0.9046438881682486   0.6282119777830519       0.16271650036125607
 0.13027892373965533  0.18887153454128924      0.3656173314780382
 0.8105579896722099   0.8689278012808201    …  0.613575621252296
 0.3501936207693894   0.41662154485059477      0.634150209365973
 0.5371570288242542   0.7182968669111338       0.3200262911743803
 0.9126028660250189   0.25564178492353906      0.23743297526797136
 0.5819814278543964   0.9943728715581492       0.4875339524077975
10×10 LinearMaps.WrappedMap{Float64} of
 0.6769273787529222   0.036539631768852665  …  0.9873418166811534
 0.6765549649256377   0.9624717119719399       0.3575343347655404
 0.31545830565381205  0.846611890984601        0.07509443800525162
 0.9046438881682486   0.6282119777830519       0.16271650036125607
 0.13027892373965533  0.18887153454128924      0.3656173314780382
 0.8105579896722099   0.8689278012808201    …  0.613575621252296
 0.3501936207693894   0.41662154485059477      0.634150209365973
 0.5371570288242542   0.7182968669111338       0.3200262911743803
 0.9126028660250189   0.25564178492353906      0.23743297526797136
 0.5819814278543964   0.9943728715581492       0.4875339524077975
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719     0.458876698914481    …  0.21599839571588952
 0.5444272069489469     0.30974679189517595     0.20158982970939365
 0.0039023841368437395  0.1743141153244383      0.5255090943219167
 0.6585137742811065     0.21529067784534073     0.09553647923800157
 0.6810489351017359     0.7726713554570053      0.88655004487403
 0.02948775918770319    0.804402117644776    …  0.8520117918594712
 0.981317366746389      0.42937017270368405     0.723298669979153
 0.05590009791874673    0.23243683344460941     0.7504218236329141
 0.6105003794996771     0.23372276641277856     0.5026331262236272
 0.45419955654642186    0.9829667847054768      0.5560613057463222
10×10 LinearMaps.WrappedMap{Float64} of
 0.8700744216295719     0.458876698914481    …  0.21599839571588952
 0.5444272069489469     0.30974679189517595     0.20158982970939365
 0.0039023841368437395  0.1743141153244383      0.5255090943219167
 0.6585137742811065     0.21529067784534073     0.09553647923800157
 0.6810489351017359     0.7726713554570053      0.88655004487403
 0.02948775918770319    0.804402117644776    …  0.8520117918594712
 0.981317366746389      0.42937017270368405     0.723298669979153
 0.05590009791874673    0.23243683344460941     0.7504218236329141
 0.6105003794996771     0.23372276641277856     0.5026331262236272
 0.45419955654642186    0.9829667847054768      0.5560613057463222

julia> N = 100
100

julia> function myft(v::AbstractVector)
         # not so fast fourier transform
         N = length(v)
         w = zeros(complex(eltype(v)), N)
         for k = 1:N
             kappa = (2*(k-1)/N)*pi
             for n = 1:N
                 w[k] += v[n]*exp(kappa*(n-1)*im)
             end
         end
         return w
       end
myft (generic function with 1 method)

julia> MyFT = LinearMap{ComplexF64}(myft, N)
100×100 LinearMaps.FunctionMap{Complex{Float64}}(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)

julia> MyFT'
100×100 LinearMaps.AdjointMap{Complex{Float64}} of
(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)

julia> J = LinearMap(3I, 100)
100×100 LinearMaps.UniformScalingMap{Int64}
 3

julia> 2MyFT + J
100×100 LinearMaps.LinearCombination{Complex{Float64}} with 2 maps:
100×100 LinearMaps.CompositeMap{Complex{Float64}} with 2 maps:
100×100 LinearMaps.FunctionMap{Complex{Float64}}(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)
100×100 LinearMaps.UniformScalingMap{Int64}
 2
100×100 LinearMaps.UniformScalingMap{Int64}
 3
```
I would like to give an idea of the hierarchy by adding indention to lower-order maps, but I don't know yet how to do that (across several lines, with potentially increasing width).

Of course, the details are up for discussion, now that we have something to start from. Needless to say that I can't help but finding it beautiful. 🤣 