### PR TITLE
(Even) Better LinearMap display

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,96 +1,74 @@
 # summary
-function Base.summary(io::IO, A::LinearMap)
-    print(io, Base.dims2string(size(A)))
-    print(io, ' ')
-    _show_typeof(io, A)
+Base.summary(io::IO, A::LinearMap) = println(io, map_summary(A))
+function map_summary(A::LinearMap)
+    Base.dims2string(size(A)) * ' ' * _show_typeof(A)
 end
 
 # show
-Base.show(io::IO, A::LinearMap) = (summary(io, A); _show(io, A))
-_show(io::IO, ::LinearMap) = nothing
-function _show(io::IO, A::FunctionMap{T,F,Nothing}) where {T,F}
-    print(io, "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
+Base.show(io::IO, A::LinearMap) = println(io, map_show(io, A, 0))
+
+map_show(io::IO, A::LinearMap, i) = " "^i * map_summary(A) * _show(io, A, i)
+_show(io::IO, ::LinearMap, _) = ""
+function _show(io::IO, A::FunctionMap{T,F,Nothing}, _) where {T,F}
+    "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))"
 end
-function _show(io::IO, A::FunctionMap)
-    print(io, "($(A.f), $(A.fc); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))")
+function _show(io::IO, A::FunctionMap, _)
+    "($(A.f), $(A.fc); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))"
 end
-function _show(io::IO, A::Union{CompositeMap,LinearCombination,KroneckerMap,KroneckerSumMap})
+function _show(io::IO, A::Union{CompositeMap,LinearCombination,KroneckerMap,KroneckerSumMap}, i)
     n = length(A.maps)
-    println(io, " with $n map", n>1 ? "s" : "", ":")
-    print_maps(io, A.maps)
+    " with $n map" * (n>1 ? "s" : "") * ":\n" * print_maps(io, A.maps, i+2)
 end
-function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap})
-    print(io, " of ")
-    L = A.lmap
-    if A isa MatrixMap
-        # summary(io, L)
-        # println(io, ":")
-        # Base.print_matrix(io, L)
-        print(io, typeof(L))
-    else
-        show(io, L)
-    end
+function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap}, i)
+    " of\n" * (A isa MatrixMap ? " "^(i+2) * string(typeof(parent(A))) : map_show(io, parent(A), i+2))
 end
-function _show(io::IO, A::BlockMap)
+function _show(io::IO, A::BlockMap, i)
     nrows = length(A.rows)
     n = length(A.maps)
-    println(io, " with $n block map", n>1 ? "s" : "", " in $nrows block row", nrows>1 ? "s" : "")
-    print_maps(io, A.maps)
+    " with $n block map" * (n>1 ? "s" : "") * " in $nrows block row" * (nrows>1 ? "s" : "") *
+        "\n" * print_maps(io, A.maps, i+2)
 end
-function _show(io::IO, A::BlockDiagonalMap)
+function _show(io::IO, A::BlockDiagonalMap, i)
     n = length(A.maps)
-    println(io, " with $n diagonal block map", n>1 ? "s" : "")
-    print_maps(io, A.maps)
+    " with $n diagonal block map" * (n>1 ? "s" : "") * ":\n" * print_maps(io, A.maps, i+2)
 end
-function _show(io::IO, J::UniformScalingMap)
-    s = "$(J.λ)"
-    print(io, " with scaling factor: $s")
+function _show(io::IO, J::UniformScalingMap, _)
+    " with scaling factor: $(J.λ)"
 end
-function _show(io::IO, A::ScaledMap{T}) where {T}
-    println(io, " with scale: $(A.λ) of")
-    show(io, A.lmap)
+function _show(io::IO, A::ScaledMap{T}, i) where {T}
+    " with scale: $(A.λ) of\n" * map_show(io, A.lmap, i+2)
 end
 
 # helper functions
-function _show_typeof(io::IO, A::LinearMap{T}) where {T}
-    Base.show_type_name(io, typeof(A).name)
-    print(io, '{')
-    show(io, T)
-    print(io, '}')
+function _show_typeof(A::LinearMap{T}) where {T}
+    string(typeof(A).name) * '{' * string(T) * '}'
 end
 
-function print_maps(io::IO, maps::Tuple{Vararg{LinearMap}})
+function print_maps(io::IO, maps::Tuple{Vararg{LinearMap}}, k)
     n = length(maps)
+    str = ""
     if get(io, :limit, true) && n > 10
         s = 1:5
         e = n-5:n
         if e[1] - s[end] > 1
             for i in s
-                # print(io, ' ')
-                show(io, maps[i])
-                println(io, "")
+                str *= map_show(io, maps[i], k) * "\n"
             end
-            print(io, "⋮")
+            str *= " "^k * "⋮"
             for i in e
-                println(io, "")
-                show(io, maps[i])
+                str *= "\n" * map_show(io, maps[i], k)
             end
         else
             for i in 1:n-1
-                # print(io, ' ')
-                show(io, maps[i])
-                println(io, "")
+                str *= map_show(io, maps[i], k) * "\n"
             end
-            # print(io, ' ')
-            show(io, last(maps))
+            str *= map_show(io, last(maps), k)
         end
     else
         for i in 1:n-1
-            # print(io, ' ')
-            show(io, maps[i])
-            println(io, "")
+            str *= map_show(io, maps[i], k) * "\n"
         end
-        # print(io, ' ')
-        show(io, last(maps))
+        str *= map_show(io, last(maps), k)
     end
+    return str
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -5,9 +5,10 @@ function map_summary(A::LinearMap)
 end
 
 # show
-Base.show(io::IO, A::LinearMap) = println(io, map_show(io, A, 0))
+Base.show(io::IO, A::LinearMap) = print(io, map_show(io, A, 0))
 
 map_show(io::IO, A::LinearMap, i) = " "^i * map_summary(A) * _show(io, A, i)
+map_show(io::IO, A::AbstractMatrix, i) = " "^i * string(typeof(A))
 _show(io::IO, ::LinearMap, _) = ""
 function _show(io::IO, A::FunctionMap{T,F,Nothing}, _) where {T,F}
     "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))"
@@ -20,7 +21,7 @@ function _show(io::IO, A::Union{CompositeMap,LinearCombination,KroneckerMap,Kron
     " with $n map" * (n>1 ? "s" : "") * ":\n" * print_maps(io, A.maps, i+2)
 end
 function _show(io::IO, A::Union{AdjointMap,TransposeMap,WrappedMap}, i)
-    " of\n" * (A isa MatrixMap ? " "^(i+2) * string(typeof(parent(A))) : map_show(io, parent(A), i+2))
+    " of\n" * map_show(io, parent(A), i+2)
 end
 function _show(io::IO, A::BlockMap, i)
     nrows = length(A.rows)

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,5 +1,5 @@
 # summary
-Base.summary(io::IO, A::LinearMap) = println(io, map_summary(A))
+Base.summary(io::IO, A::LinearMap) = print(io, map_summary(A))
 function map_summary(A::LinearMap)
     Base.dims2string(size(A)) * ' ' * _show_typeof(A)
 end
@@ -42,7 +42,7 @@ end
 
 # helper functions
 function _show_typeof(A::LinearMap{T}) where {T}
-    string(typeof(A).name) * '{' * string(T) * '}'
+    split(string(typeof(A)), '{')[1] * '{' * string(T) * '}'
 end
 
 function print_maps(io::IO, maps::Tuple{Vararg{LinearMap}}, k)

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -12,6 +12,7 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     L = sum(fill(CS!, n))
     @test_throws AssertionError LinearMaps.LinearCombination{Float64}((CS!, CS!))
     @test occursin("10×10 LinearMaps.LinearCombination{$(eltype(L))}", sprint((t, s) -> show(t, "text/plain", s), L))
+    @test occursin("10×10 LinearMaps.LinearCombination{$(eltype(L))}", sprint((t, s) -> show(t, "text/plain", s), L+CS!))
     @test parent(L) == ntuple(_ -> CS!, 10)
     @test mul!(u, L, v) ≈ n * cumsum(v)
     b = @benchmarkable mul!($u, $L, $v, 2, 2)


### PR DESCRIPTION
This is how it looks now:
```julia
julia> using LinearMaps, LinearAlgebra

julia> A = LinearMap(rand(10, 10))
10×10 LinearMaps.WrappedMap{Float64} of
  Array{Float64,2}

julia> B = LinearMap(rand(10, 10))
10×10 LinearMaps.WrappedMap{Float64} of
  Array{Float64,2}

julia> A + B
10×10 LinearMaps.LinearCombination{Float64} with 2 maps:
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}

julia> A*B
10×10 LinearMaps.CompositeMap{Float64} with 2 maps:
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}

julia> A'
10×10 LinearMaps.WrappedMap{Float64} of
  LinearAlgebra.Adjoint{Float64,Array{Float64,2}}

julia> transpose(B)
10×10 LinearMaps.WrappedMap{Float64} of
  LinearAlgebra.Transpose{Float64,Array{Float64,2}}

julia> [A A; B B]
20×20 LinearMaps.BlockMap{Float64} with 4 block maps in 2 block rows
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}
  10×10 LinearMaps.WrappedMap{Float64} of
    Array{Float64,2}

julia> N = 100
100

julia> function myft(v::AbstractVector)
                       # not so fast fourier transform
                       N = length(v)
                       w = zeros(complex(eltype(v)), N)
                       for k = 1:N
                           kappa = (2*(k-1)/N)*pi
                           for n = 1:N
                               w[k] += v[n]*exp(kappa*(n-1)*im)
                           end
                       end
                       return w
                     end
myft (generic function with 1 method)

julia> MyFT = LinearMap{ComplexF64}(myft, N)
100×100 LinearMaps.FunctionMap{Complex{Float64}}(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)

julia> MyFT'
100×100 LinearMaps.AdjointMap{Complex{Float64}} of
  100×100 LinearMaps.FunctionMap{Complex{Float64}}(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)

julia> J = LinearMap(3I, 100)
100×100 LinearMaps.UniformScalingMap{Int64} with scaling factor: 3

julia> 2MyFT + J
100×100 LinearMaps.LinearCombination{Complex{Float64}} with 2 maps:
  100×100 LinearMaps.ScaledMap{Complex{Float64}} with scale: 2 of
    100×100 LinearMaps.FunctionMap{Complex{Float64}}(myft; ismutating=false, issymmetric=false, ishermitian=false, isposdef=false)
  100×100 LinearMaps.UniformScalingMap{Int64} with scaling factor: 3
```