### PR TITLE
Improve performance of Kronecker products

### DIFF
--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -125,7 +125,7 @@ end
 @inline function _kronmul!(y, B, x, At::UniformScalingMap, _)
     na, ma = size(At)
     mb, nb = size(B)
-    X = reshape(x, (nb, ma))
+    X = reshape(x, (nb, na))
     Y = reshape(y, (mb, ma))
     _unsafe_mul!(Y, B, X, _parent(At), false)
     return y
@@ -133,7 +133,7 @@ end
 @inline function _kronmul!(y, B, x, At::MatrixMap, _)
     na, ma = size(At)
     mb, nb = size(B)
-    X = reshape(x, (nb, ma))
+    X = reshape(x, (nb, na))
     Y = reshape(y, (mb, ma))
     if nb*ma < mb*na
         _unsafe_mul!(Y, B, X * _parent(At))

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -128,7 +128,7 @@ end
     mb, nb = size(B)
     X = reshape(x, (nb, na))
     Y = reshape(y, (mb, ma))
-    _unsafe_mul!(Y, B, X, _parent(At), false)
+    _unsafe_mul!(Y, B, X, At.λ, false)
     return y
 end
 @inline function _kronmul!(y, B, x, At::MatrixMap, _)
@@ -137,9 +137,9 @@ end
     X = reshape(x, (nb, na))
     Y = reshape(y, (mb, ma))
     if nb*ma < mb*na
-        _unsafe_mul!(Y, B, X * _parent(At))
+        _unsafe_mul!(Y, B, X * At.lmap)
     else
-        _unsafe_mul!(Y, Matrix(B*X), _parent(At))
+        _unsafe_mul!(Y, Matrix(B*X), At.lmap)
     end
     return y
 end

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -107,9 +107,10 @@ Base.:(==)(A::KroneckerMap, B::KroneckerMap) = (eltype(A) == eltype(B) && A.maps
 # multiplication helper functions
 #################
 
-@inline function _kronmul!(y, B, X, At, T)
+@inline function _kronmul!(y, B, x, At, T)
     na, ma = size(At)
     mb, nb = size(B)
+    X = reshape(x, (nb, na))
     v = zeros(T, ma)
     temp1 = similar(y, na)
     temp2 = similar(y, nb)

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -17,7 +17,6 @@ MulStyle(::UniformScalingMap) = FiveArg()
 
 # properties
 Base.size(A::UniformScalingMap) = (A.M, A.M)
-_parent(A::UniformScalingMap) = A.λ
 Base.isreal(A::UniformScalingMap) = isreal(A.λ)
 LinearAlgebra.issymmetric(::UniformScalingMap) = true
 LinearAlgebra.ishermitian(A::UniformScalingMap) = isreal(A)

--- a/src/wrappedmap.jl
+++ b/src/wrappedmap.jl
@@ -38,7 +38,6 @@ Base.:(==)(A::MatrixMap, B::MatrixMap) =
 
 # properties
 Base.size(A::WrappedMap) = size(A.lmap)
-_parent(A::WrappedMap) = A.lmap
 LinearAlgebra.issymmetric(A::WrappedMap) = A._issymmetric
 LinearAlgebra.ishermitian(A::WrappedMap) = A._ishermitian
 LinearAlgebra.isposdef(A::WrappedMap) = A._isposdef

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -8,6 +8,10 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         LA = LinearMap(A)
         LB = LinearMap(B)
         LK = @inferred kron(LA, LB)
+        @test kron(LA, 2LB) isa LinearMaps.ScaledMap
+        @test kron(3LA, LB) isa LinearMaps.ScaledMap
+        @test kron(3LA, 2LB) isa LinearMaps.ScaledMap
+        @test kron(3LA, 2LB).λ == 6
         @test_throws ErrorException LinearMaps.KroneckerMap{Float64}((LA, LB))
         @test occursin("6×6 LinearMaps.KroneckerMap{$(eltype(LK))}", sprint((t, s) -> show(t, "text/plain", s), LK))
         @test @inferred size(LK) == size(K)

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -11,7 +11,6 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     w = similar(v)
     Id = @inferred LinearMap(I, 10)
     @test occursin("10×10 LinearMaps.UniformScalingMap{Bool}", sprint((t, s) -> show(t, "text/plain", s), Id))
-    @test LinearMaps._parent(Id) == true
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, 10, 20)
     @test_throws ErrorException LinearMaps.UniformScalingMap(1, (10, 20))
     @test size(Id) == (10, 10)

--- a/test/wrappedmap.jl
+++ b/test/wrappedmap.jl
@@ -7,7 +7,6 @@ using Test, LinearMaps, LinearAlgebra
     SB = B'B + I
     L = @inferred LinearMap{Float64}(A)
     @test occursin("10×20 LinearMaps.WrappedMap{Float64}", sprint((t, s) -> show(t, "text/plain", s), L))
-    @test LinearMaps._parent(L) === A
     MA = @inferred LinearMap(SA)
     MB = @inferred LinearMap(SB)
     @test eltype(Matrix{Complex{Float32}}(LinearMap(A))) <: Complex


### PR DESCRIPTION
While investigating #125 I realized that it is highly advantageous to factor out scalings out of the Kronecker product. This simplifies what needs to be perfored in the `_kronmul!` kernels. We do something similar in the normal product `*` as well. I also slightly rearranged the kernels for UniformScalingMaps, which yields another nice performance improvement.

Fixes #125.