### PR TITLE
Restrict ScaledMap to RealOrComplex

### DIFF
--- a/src/scaledmap.jl
+++ b/src/scaledmap.jl
@@ -63,9 +63,3 @@ for (In, Out) in ((AbstractVector, AbstractVecOrMat),
         end
     end
 end
-function _unsafe_mul!(y::AbstractVecOrMat, A::ScaledMap, x::AbstractVector, α::Number, β::Number)
-    return _generic_mapvec_mul!(y, A, x, α, β)
-end
-function _unsafe_mul!(y::AbstractMatrix, A::ScaledMap, x::AbstractMatrix, α::Number, β::Number)
-    return _generic_mapmat_mul!(y, A, x, α, β)
-end

--- a/src/scaledmap.jl
+++ b/src/scaledmap.jl
@@ -1,14 +1,14 @@
 """
-    struct ScaledMap{T, S<:RealOrComplex, A<:LinearMap} <: LinearMap{T}
-
-Lazy representation of real or complex scaled maps ``\\alpha A``.
+Lazy representation of a scaled map `λ * A = A * λ` with real or complex map
+`A <: LinearMap{RealOrComplex}` and real or complex scaling factor
+`λ <: RealOrComplex`.
 """
-struct ScaledMap{T, S<:RealOrComplex, A<:LinearMap} <: LinearMap{T}
+struct ScaledMap{T, S<:RealOrComplex, L<:LinearMap} <: LinearMap{T}
     λ::S
-    lmap::A
-    function ScaledMap{T}(λ::S, lmap::A) where {T, S <: RealOrComplex, A <: LinearMap{<:RealOrComplex}}
-        @assert Base.promote_op(*, S, eltype(lmap)) == T "target type $T cannot hold products of $S and $(eltype(lmap)) objects"
-        new{T,S,A}(λ, lmap)
+    lmap::L
+    function ScaledMap{T}(λ::S, A::L) where {T, S <: RealOrComplex, L <: LinearMap{<:RealOrComplex}}
+        @assert Base.promote_op(*, S, eltype(A)) == T "target type $T cannot hold products of $S and $(eltype(A)) objects"
+        new{T,S,L}(λ, A)
     end
 end
 

--- a/test/numbertypes.jl
+++ b/test/numbertypes.jl
@@ -11,6 +11,7 @@ Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
     γ = Quaternion.(rand(4)...) # "Number"
     α = UniformScaling(γ)
     β = UniformScaling(Quaternion.(rand(4)...))
+    λ = rand(ComplexF64)
     L = LinearMap(A)
     @test Array(L) == A
     @test Array(L') == A'
@@ -25,8 +26,12 @@ Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
     @test L' * x ≈ A' * x
     @test α * (L * x) ≈ α * (A * x)
     @test α * L * x ≈ α * A * x
+    @test L * α * x ≈ A * α * x
     @test 3L * x ≈ 3A * x
     @test 3L' * x ≈ 3A' * x
+    @test λ*L isa LinearMaps.CompositeMap
+    @test λ*L * x ≈ λ*A * x
+    @test λ*L' * x ≈ λ*A' * x
     @test α * (3L * x) ≈ α * (3A * x)
     @test (@inferred α * 3L) * x ≈ α * 3A * x
     @test (@inferred 3L * α) * x ≈ 3A * α * x

--- a/test/numbertypes.jl
+++ b/test/numbertypes.jl
@@ -8,6 +8,7 @@ Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
     x = Quaternion.(rand(10), rand(10), rand(10), rand(10))
     v = rand(10)
     A = Quaternion.(rand(10,10), rand(10,10), rand(10,10), rand(10,10))
+    B = rand(ComplexF64, 10, 10)
     γ = Quaternion.(rand(4)...) # "Number"
     α = UniformScaling(γ)
     β = UniformScaling(Quaternion.(rand(4)...))
@@ -30,6 +31,8 @@ Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
     @test 3L * x ≈ 3A * x
     @test 3L' * x ≈ 3A' * x
     @test λ*L isa LinearMaps.CompositeMap
+    @test γ * (λ * LinearMap(B)) isa LinearMaps.CompositeMap
+    @test (λ * LinearMap(B)) * γ isa LinearMaps.CompositeMap
     @test λ*L * x ≈ λ*A * x
     @test λ*L' * x ≈ λ*A' * x
     @test α * (3L * x) ≈ α * (3A * x)
@@ -62,12 +65,13 @@ Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
     @test Array(-L) == -A
     @test Array(γ \ L) ≈ γ \ A
     @test Array(L / γ) ≈ A / γ
-    M = rand(ComplexF64, 10, 10); α = rand(ComplexF64); y = α * M * x
+    M = rand(ComplexF64, 10, 10); α = rand(ComplexF64);
+    y = α * M * x; Y = α * M * A
     @test (α * LinearMap(M)) * x ≈ (quat(α) * LinearMap(M)) * x ≈ y
-    @test mul!(copy(y), LinearMap(M), x, α, false) ≈ M * x * α
-    @test mul!(copy(y), LinearMap(M), x, quat(α), false) ≈ M * x * α
-    @test mul!(similar(M*A), LinearMap(M), A) ≈ M * A
-    @test mul!(similar(M*A), LinearMap(M), A, α, false) ≈ M * A * α
+    @test mul!(copy(y), α * LinearMap(M), x, α, false) ≈ α * M * x * α
+    @test mul!(copy(y), α * LinearMap(M), x, quat(α), false) ≈ α * M * x * α
+    @test mul!(copy(Y), α * LinearMap(M), A) ≈ α * M * A
+    @test mul!(copy(Y), α * LinearMap(M), A, α, false) ≈ α * M * A * α
 end
 
 @testset "nonassociative number type" begin

--- a/test/numbertypes.jl
+++ b/test/numbertypes.jl
@@ -1,5 +1,9 @@
 using Test, LinearMaps, LinearAlgebra, Quaternions
 
+# type piracy because Quaternions.jl doesn't have it right
+Base.:(*)(z::Complex{T}, q::Quaternion{T}) where {T<:Real} = quat(z) * q
+Base.:(*)(q::Quaternion{T}, z::Complex{T}) where {T<:Real} = q * quat(z)
+
 @testset "noncommutative number type" begin
     x = Quaternion.(rand(10), rand(10), rand(10), rand(10))
     v = rand(10)
@@ -53,6 +57,12 @@ using Test, LinearMaps, LinearAlgebra, Quaternions
     @test Array(-L) == -A
     @test Array(γ \ L) ≈ γ \ A
     @test Array(L / γ) ≈ A / γ
+    M = rand(ComplexF64, 10, 10); α = rand(ComplexF64); y = α * M * x
+    @test (α * LinearMap(M)) * x ≈ (quat(α) * LinearMap(M)) * x ≈ y
+    @test mul!(copy(y), LinearMap(M), x, α, false) ≈ M * x * α
+    @test mul!(copy(y), LinearMap(M), x, quat(α), false) ≈ M * x * α
+    @test mul!(similar(M*A), LinearMap(M), A) ≈ M * A
+    @test mul!(similar(M*A), LinearMap(M), A, α, false) ≈ M * A * α
 end
 
 @testset "nonassociative number type" begin


### PR DESCRIPTION
While investigating #125, I also noticed that we should enforce commutative eltypes in `ScaledMap`s more strongly, as @JeffFessler probably had in his first draft, which later got spoiled by me. Otherwise the results may be wrong when you have a quaternion-map and/or -vector and a complex scaling. I'll probably need to add a test case later.