### PR TITLE
Adjust Tuple{Vararg{LinearMap}} notation

### DIFF
--- a/src/composition.jl
+++ b/src/composition.jl
@@ -27,10 +27,10 @@ for (f, _f, g) in ((:issymmetric, :_issymmetric, :transpose),
         LinearAlgebra.$f(A::CompositeMap) = $_f(A.maps)
         $_f(maps::Tuple{}) = true
         $_f(maps::Tuple{<:LinearMap}) = $f(maps[1])
-        $_f(maps::Tuple{Vararg{<:LinearMap}}) =
+        $_f(maps::Tuple{Vararg{LinearMap}}) =
             maps[end] == $g(maps[1]) && $_f(Base.front(Base.tail(maps)))
         # since the introduction of ScaledMap, the following cases cannot occur
-        # function $_f(maps::Tuple{Vararg{<:LinearMap}}) # length(maps) >= 2
+        # function $_f(maps::Tuple{Vararg{LinearMap}}) # length(maps) >= 2
             # if maps[1] isa UniformScalingMap{<:RealOrComplex}
             #     return $f(maps[1]) && $_f(Base.tail(maps))
             # elseif maps[end] isa UniformScalingMap{<:RealOrComplex}


### PR DESCRIPTION
If I understand correctly, this is how it's supposed to be written after https://github.com/JuliaLang/julia/pull/38136 (whose exact consequences I don't understand), and I was indeed seeing warnings during the tests on my local nightly (though not in the CI runs):
```julia
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
WARNING: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
```