### PR TITLE
Add quality assurance tests, fix ambiguity

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearMaps"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "3.2.0"
+version = "3.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -18,4 +19,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "SparseArrays", "Test", "BenchmarkTools", "InteractiveUtils", "Quaternions"]
+test = ["Aqua", "BenchmarkTools", "InteractiveUtils", "LinearAlgebra", "Quaternions", "SparseArrays", "Test"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The only requirement for a `LinearMap` is that it can act on a vector (by multip
 
 | **Documentation**                                                               | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![stable docs][docs-stable-img]][docs-stable-url] [![dev docs][docs-dev-img]][docs-dev-url] | [![build status][build-img]][build-url] [![coverage][codecov-img]][codecov-url] [![license][license-img]][license-url] |
+| [![stable docs][docs-stable-img]][docs-stable-url] [![dev docs][docs-dev-img]][docs-dev-url] | [![build status][build-img]][build-url] [![coverage][codecov-img]][codecov-url] [![Aqua QA](aqua-img)](aqua-url) [![license][license-img]][license-url] |
 
 ## Installation
 
@@ -38,3 +38,6 @@ julia> import Pkg; Pkg.add("LinearMaps")
 
 [license-img]: http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat
 [license-url]: LICENSE.md
+
+[aqua-img]: https://img.shields.io/badge/Aqua.jl-%F0%9F%8C%A2-aqua.svg
+[aqua-url]: https://github.com/JuliaTesting/Aqua.jl

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The only requirement for a `LinearMap` is that it can act on a vector (by multip
 
 | **Documentation**                                                               | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![stable docs][docs-stable-img]][docs-stable-url] [![dev docs][docs-dev-img]][docs-dev-url] | [![build status][build-img]][build-url] [![coverage][codecov-img]][codecov-url] [![Aqua QA](aqua-img)](aqua-url) [![license][license-img]][license-url] |
+| [![stable docs][docs-stable-img]][docs-stable-url] [![dev docs][docs-dev-img]][docs-dev-url] | [![build status][build-img]][build-url] [![coverage][codecov-img]][codecov-url] [![Aqua QA][aqua-img]][aqua-url] [![license][license-img]][license-url] |
 
 ## Installation
 

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -260,8 +260,6 @@ include("show.jl") # show methods for LinearMap objects
     LinearMap(A::LinearMap; kwargs...)::WrappedMap
     LinearMap(A::AbstractMatrix; kwargs...)::WrappedMap
     LinearMap(J::UniformScaling, M::Int)::UniformScalingMap
-    LinearMap(λ::Number, M::Int, N::Int) = FillMap(λ, (M, N))::FillMap
-    LinearMap(λ::Number, dims::Dims{2}) = FillMap(λ, dims)::FillMap
     LinearMap{T=Float64}(f, [fc,], M::Int, N::Int = M; kwargs...)::FunctionMap
 
 Construct a linear map object, either from an existing `LinearMap` or `AbstractMatrix` `A`,

--- a/src/composition.jl
+++ b/src/composition.jl
@@ -116,6 +116,9 @@ function Base.:(*)(A₁::CompositeMap, A₂::CompositeMap)
     T = promote_type(eltype(A₁), eltype(A₂))
     return CompositeMap{T}(tuple(A₂.maps..., A₁.maps...))
 end
+# needed for disambiguation
+Base.:(*)(A₁::ScaledMap, A₂::CompositeMap) = A₁.λ * (A₁.lmap * A₂)
+Base.:(*)(A₁::CompositeMap, A₂::ScaledMap) = (A₁ * A₂.lmap) * A₂.λ
 
 # special transposition behavior
 LinearAlgebra.transpose(A::CompositeMap{T}) where {T} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,11 @@
-using Test, LinearMaps
+using Test, LinearMaps, Aqua
 import LinearMaps: FiveArg, ThreeArg
 
 const matrixstyle = VERSION ≥ v"1.3.0-alpha.115" ? FiveArg() : ThreeArg()
 
 const testallocs = VERSION ≥ v"1.4-"
+
+Aqua.test_all(LinearMaps)
 
 include("linearmaps.jl")
 


### PR DESCRIPTION
This adds Aqua.jl to the test dependencies. It tests for, among others, method ambiguities, which I'm fixing here.