### PR TITLE
Allow wrapping of vectors, extend Kronecker product

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearMaps"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "3.2.4"
+version = "3.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/history.md
+++ b/docs/src/history.md
@@ -1,5 +1,13 @@
 # Version history
 
+## What's new in v3.3
+
+* `AbstractVector`s can now be wrapped by a `LinearMap` just like `AbstractMatrix``
+  typed objects. Upon wrapping, there are not implicitly reshaped to matrices. This
+  feature might be helpful, for instance, in the lazy representation of rank-1
+  operators `kron(LinearMap(u), v') == ⊗(u, v') == u ⊗ v'` for vectors `u` and `v`.
+  The action on vectors,`(u⊗v')*x`, is implemented optimally via `u*(v'x)`.
+
 ## What's new in v3.2
 
 * In-place left-multiplication `mul!(Y, X, A::LinearMap)` is now allowed for

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -265,7 +265,7 @@ include("show.jl") # show methods for LinearMap objects
     LinearMap(J::UniformScaling, M::Int)::UniformScalingMap
     LinearMap{T=Float64}(f, [fc,], M::Int, N::Int = M; kwargs...)::FunctionMap
 
-Construct a linear map object, either from an existing `LinearMap` or `AbstractMatrix` `A`,
+Construct a linear map object, either from an existing `LinearMap` or `AbstractVecOrMat` `A`,
 with the purpose of redefining its properties via the keyword arguments `kwargs`;
 a `UniformScaling` object `J` with specified (square) dimension `M`; from a `Number`
 object to lazily represent filled matrices; or

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -34,9 +34,9 @@ MulStyle(::FiveArg, ::ThreeArg) = ThreeArg()
 MulStyle(::ThreeArg, ::ThreeArg) = ThreeArg()
 MulStyle(::LinearMap) = ThreeArg() # default
 @static if VERSION ≥ v"1.3.0-alpha.115"
-    MulStyle(::AbstractMatrix) = FiveArg()
+    MulStyle(::AbstractVecOrMat) = FiveArg()
 else
-    MulStyle(::AbstractMatrix) = ThreeArg()
+    MulStyle(::AbstractVecOrMat) = ThreeArg()
 end
 MulStyle(A::LinearMap, As::LinearMap...) = MulStyle(MulStyle(A), MulStyle(As...))
 
@@ -68,8 +68,8 @@ function check_dim_mul(C, A, B)
     return nothing
 end
 
-# conversion of AbstractMatrix to LinearMap
-convert_to_lmaps_(A::AbstractMatrix) = LinearMap(A)
+# conversion of AbstractVecOrMat to LinearMap
+convert_to_lmaps_(A::AbstractVecOrMat) = LinearMap(A)
 convert_to_lmaps_(A::LinearMap) = A
 convert_to_lmaps() = ()
 convert_to_lmaps(A) = (convert_to_lmaps_(A),)
@@ -231,8 +231,8 @@ function _generic_mapmat_mul!(Y, A, X, α=true, β=false)
     return Y
 end
 
-_unsafe_mul!(y, A::MapOrMatrix, x) = mul!(y, A, x)
-_unsafe_mul!(y, A::AbstractMatrix, x, α, β) = mul!(y, A, x, α, β)
+_unsafe_mul!(y, A::MapOrVecOrMat, x) = mul!(y, A, x)
+_unsafe_mul!(y, A::AbstractVecOrMat, x, α, β) = mul!(y, A, x, α, β)
 function _unsafe_mul!(y::AbstractVecOrMat, A::LinearMap, x::AbstractVector, α, β)
     return _generic_mapvec_mul!(y, A, x, α, β)
 end
@@ -261,7 +261,7 @@ include("show.jl") # show methods for LinearMap objects
 
 """
     LinearMap(A::LinearMap; kwargs...)::WrappedMap
-    LinearMap(A::AbstractMatrix; kwargs...)::WrappedMap
+    LinearMap(A::AbstractVecOrMat; kwargs...)::WrappedMap
     LinearMap(J::UniformScaling, M::Int)::UniformScalingMap
     LinearMap{T=Float64}(f, [fc,], M::Int, N::Int = M; kwargs...)::FunctionMap
 
@@ -293,7 +293,7 @@ For the function-based constructor, there is one more keyword argument:
     The default value is guessed by looking at the number of arguments of the first
     occurrence of `f` in the method table.
 """
-LinearMap(A::MapOrMatrix; kwargs...) = WrappedMap(A; kwargs...)
+LinearMap(A::MapOrVecOrMat; kwargs...) = WrappedMap(A; kwargs...)
 LinearMap(J::UniformScaling, M::Int) = UniformScalingMap(J.λ, M)
 LinearMap(f, M::Int; kwargs...) = LinearMap{Float64}(f, M; kwargs...)
 LinearMap(f, M::Int, N::Int; kwargs...) = LinearMap{Float64}(f, M, N; kwargs...)

--- a/src/blockmap.jl
+++ b/src/blockmap.jl
@@ -38,15 +38,15 @@ function rowcolranges(maps, rows)
     rowstart = 1
     for (i, row) in enumerate(rows)
         mapind += 1
-        rowend = rowstart + size(maps[mapind], 1) - 1
+        rowend = rowstart + Int(size(maps[mapind], 1))::Int - 1
         rowranges = Base.setindex(rowranges, rowstart:rowend, i)
         colstart = 1
-        colend = size(maps[mapind], 2)
+        colend = Int(size(maps[mapind], 2))::Int
         colranges = Base.setindex(colranges, colstart:colend, mapind)
         for colind in 2:row
             mapind += 1
             colstart = colend + 1
-            colend += size(maps[mapind], 2)
+            colend += Int(size(maps[mapind], 2))::Int
             colranges = Base.setindex(colranges, colstart:colend, mapind)
         end
         rowstart = rowend + 1
@@ -226,9 +226,7 @@ function check_dim(A, dim, n)
     return nothing
 end
 
-promote_to_lmaps_(n::Int, dim, A::AbstractMatrix) = (check_dim(A, dim, n); LinearMap(A))
-promote_to_lmaps_(n::Int, dim, A::AbstractVector) =
-    (check_dim(A, dim, n); LinearMap(reshape(A, length(A), 1)))
+promote_to_lmaps_(n::Int, dim, A::AbstractVecOrMat) = (check_dim(A, dim, n); LinearMap(A))
 promote_to_lmaps_(n::Int, dim, J::UniformScaling) = UniformScalingMap(J.λ, n)
 promote_to_lmaps_(n::Int, dim, A::LinearMap) = (check_dim(A, dim, n); A)
 promote_to_lmaps(n, k, dim) = ()

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -59,8 +59,8 @@ Base.convert(::Type{AbstractMatrix}, J::UniformScalingMap) = Diagonal(fill(J.λ,
 # WrappedMap
 Base.Matrix{T}(A::WrappedMap) where {T} = Matrix{T}(A.lmap)
 Base.convert(::Type{T}, A::WrappedMap) where {T<:Matrix} = convert(T, A.lmap)
-Base.convert(::Type{T}, A::VectorMap) where {T<:Matrix} =
-    copyto!(Matrix{eltype(T)}(undef, size(A)), A.lmap)
+Base.Matrix{T}(A::VectorMap) where {T} = copyto!(Matrix{eltype(T)}(undef, size(A)), A.lmap)
+Base.convert(::Type{T}, A::VectorMap) where {T<:Matrix} = T(A)
 Base.convert(::Type{AbstractMatrix}, A::WrappedMap) = convert(AbstractMatrix, A.lmap)
 SparseArrays.sparse(A::WrappedMap) = sparse(A.lmap)
 Base.convert(::Type{SparseMatrixCSC}, A::WrappedMap) = convert(SparseMatrixCSC, A.lmap)

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -50,7 +50,7 @@ SparseArrays.SparseMatrixCSC(A::LinearMap) = sparse(A)
 Base.Matrix{T}(A::ScaledMap{<:Any, <:Any, <:VecOrMatMap}) where {T} =
     convert(Matrix{T}, A.λ * A.lmap.lmap)
 SparseArrays.sparse(A::ScaledMap{<:Any, <:Any, <:VecOrMatMap}) =
-    convert(AbstractSparseArray, A.λ * A.lmap.lmap)
+    A.λ * sparse(A.lmap.lmap)
 
 # UniformScalingMap
 Base.Matrix{T}(J::UniformScalingMap) where {T} = Matrix{T}(J.λ*I, size(J))

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -50,7 +50,7 @@ SparseArrays.SparseMatrixCSC(A::LinearMap) = sparse(A)
 Base.Matrix{T}(A::ScaledMap{<:Any, <:Any, <:VecOrMatMap}) where {T} =
     convert(Matrix{T}, A.λ * A.lmap.lmap)
 SparseArrays.sparse(A::ScaledMap{<:Any, <:Any, <:VecOrMatMap}) =
-    convert(SparseMatrixCSC, A.λ * A.lmap.lmap)
+    convert(AbstractSparseArray, A.λ * A.lmap.lmap)
 
 # UniformScalingMap
 Base.Matrix{T}(J::UniformScalingMap) where {T} = Matrix{T}(J.λ*I, size(J))
@@ -59,6 +59,8 @@ Base.convert(::Type{AbstractMatrix}, J::UniformScalingMap) = Diagonal(fill(J.λ,
 # WrappedMap
 Base.Matrix{T}(A::WrappedMap) where {T} = Matrix{T}(A.lmap)
 Base.convert(::Type{T}, A::WrappedMap) where {T<:Matrix} = convert(T, A.lmap)
+Base.convert(::Type{T}, A::VectorMap) where {T<:Matrix} =
+    copyto!(Matrix{eltype(T)}(undef, size(A)), A.lmap)
 Base.convert(::Type{AbstractMatrix}, A::WrappedMap) = convert(AbstractMatrix, A.lmap)
 SparseArrays.sparse(A::WrappedMap) = sparse(A.lmap)
 Base.convert(::Type{SparseMatrixCSC}, A::WrappedMap) = convert(SparseMatrixCSC, A.lmap)

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -64,18 +64,18 @@ Base.kron(A::KroneckerMap, B::ScaledMap) = kron(A, B.lmap) * B.λ
 # generic definitions
 Base.kron(A::LinearMap, B::LinearMap, C::LinearMap, Ds::LinearMap...) =
     kron(kron(A, B), C, Ds...)
-Base.kron(A::AbstractMatrix, B::LinearMap) = kron(LinearMap(A), B)
-Base.kron(A::LinearMap, B::AbstractMatrix) = kron(A, LinearMap(B))
+Base.kron(A::AbstractVecOrMat, B::LinearMap) = kron(LinearMap(A), B)
+Base.kron(A::LinearMap, B::AbstractVecOrMat) = kron(A, LinearMap(B))
 # promote AbstractMatrix arguments to LinearMaps, then take LinearMap-Kronecker product
 for k in 3:8 # is 8 sufficient?
-    Is = ntuple(n->:($(Symbol(:A, n))::AbstractMatrix), Val(k-1))
+    Is = ntuple(n->:($(Symbol(:A, n))::AbstractVecOrMat), Val(k-1))
     # yields (:A1, :A2, :A3, ..., :A(k-1))
     L = :($(Symbol(:A, k))::LinearMap)
     # yields :Ak::LinearMap
     mapargs = ntuple(n -> :(LinearMap($(Symbol(:A, n)))), Val(k-1))
     # yields (:LinearMap(A1), :LinearMap(A2), ..., :LinearMap(A(k-1)))
 
-    @eval Base.kron($(Is...), $L, As::MapOrMatrix...) =
+    @eval Base.kron($(Is...), $L, As::MapOrVecOrMat...) =
         kron($(mapargs...), $(Symbol(:A, k)), convert_to_lmaps(As...)...)
 end
 
@@ -153,13 +153,13 @@ end
     elseif nb*ma <= mb*na
         _unsafe_mul!(Y, B, X * At)
     else
-        _unsafe_mul!(Y, Matrix(B*X), transpose(A))
+        _unsafe_mul!(Y, B * X, At)
     end
     return y
 end
 const VectorMap{T} = WrappedMap{T,<:AbstractVector}
 const AdjOrTransVectorMap{T} = WrappedMap{T,<:LinearAlgebra.AdjOrTransAbsVec}
-_kronmul!(y, B::AdjOrTransVectorMap, x, a::VectorMap, _) = mul!(y, a.lmap, first(B * x))
+@inline _kronmul!(y, B::AdjOrTransVectorMap, x, a::VectorMap, _) = mul!(y, a.lmap, B.lmap * x)
 
 #################
 # multiplication with vectors

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -153,7 +153,7 @@ end
     elseif nb*ma <= mb*na
         _unsafe_mul!(Y, B, X * At)
     else
-        _unsafe_mul!(Y, B * X, At)
+        _unsafe_mul!(Y, Matrix(B * X), At)
     end
     return y
 end

--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -139,7 +139,7 @@ end
     !isone(A.λ) && rmul!(y, A.λ)
     return y
 end
-@inline function _kronmul!(y, B, x, A::MatrixMap, _)
+@inline function _kronmul!(y, B, x, A::VecOrMatMap, _)
     ma, na = size(A)
     mb, nb = size(B)
     X = reshape(x, (nb, na))
@@ -153,10 +153,13 @@ end
     elseif nb*ma <= mb*na
         _unsafe_mul!(Y, B, X * At)
     else
-        _unsafe_mul!(Y, Matrix(B*X), At)
+        _unsafe_mul!(Y, Matrix(B*X), transpose(A))
     end
     return y
 end
+const VectorMap{T} = WrappedMap{T,<:AbstractVector}
+const AdjOrTransVectorMap{T} = WrappedMap{T,<:LinearAlgebra.AdjOrTransAbsVec}
+_kronmul!(y, B::AdjOrTransVectorMap, x, a::VectorMap, _) = mul!(y, a.lmap, first(B * x))
 
 #################
 # multiplication with vectors

--- a/src/show.jl
+++ b/src/show.jl
@@ -8,7 +8,7 @@ end
 Base.show(io::IO, A::LinearMap) = print(io, map_show(io, A, 0))
 
 map_show(io::IO, A::LinearMap, i) = ' '^i * map_summary(A) * _show(io, A, i)
-map_show(io::IO, A::AbstractMatrix, i) = ' '^i * summary(A)
+map_show(io::IO, A::AbstractVecOrMat, i) = ' '^i * summary(A)
 _show(io::IO, ::LinearMap, _) = ""
 function _show(io::IO, A::FunctionMap{T,F,Nothing}, _) where {T,F}
     "($(A.f); ismutating=$(A._ismutating), issymmetric=$(A._issymmetric), ishermitian=$(A._ishermitian), isposdef=$(A._isposdef))"

--- a/test/blockmap.jl
+++ b/test/blockmap.jl
@@ -26,8 +26,10 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, BenchmarkTools, Interactive
             @test (@which [I I I A11 A11 A11]).module != LinearMaps
             @test (@which hcat(I, I, I)).module != LinearMaps
             @test (@which hcat(I, I, I, LinearMap(A11), A11, A11)).module == LinearMaps
+            maps = @inferred LinearMaps.promote_to_lmaps(ntuple(i->10, 7), 1, 1, I, I, I, LinearMap(A11), A11, A11, v)
+            @inferred LinearMaps.rowcolranges(maps, (7,))
             L = @inferred hcat(I, I, I, LinearMap(A11), A11, A11, v)
-            @test L == [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11) LinearMap(reshape(v, :, 1))]
+            @test L == [I I I LinearMap(A11) LinearMap(A11) LinearMap(A11) LinearMap(v)]
             x = rand(elty, 61)
             @test L isa LinearMaps.BlockMap{elty}
             @test L * x ≈ A * x

--- a/test/conversion.jl
+++ b/test/conversion.jl
@@ -10,6 +10,7 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, Quaternions
     β = rand()
     M = @inferred LinearMap(A)
     N = @inferred LinearMap(M)
+    U = @inferred LinearMap(v)
 
     @test Matrix(M) == A
     @test Array(M) == A
@@ -25,6 +26,8 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays, Quaternions
     @test convert(AbstractMatrix, M') isa Adjoint
     @test convert(Matrix, M*3I) == A*3
     @test convert(Matrix, M+M) == A + A
+    @test all(Matrix(U) .== v)
+    @test convert(Matrix{ComplexF32}, U) isa Matrix{ComplexF32}
 
     # UniformScalingMap
     J = LinearMap(α*I, 10)

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -22,6 +22,10 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
             @test @inferred size(LK, i) == size(K, i)
         end
         @test LK isa LinearMaps.KroneckerMap{ComplexF64}
+        L = ones(3) ⊗ ones(ComplexF64, 4)'
+        v = rand(4)
+        @test Matrix(L) == ones(3,4)
+        @test L*v ≈ fill(sum(v), 3)
 
         for transform in (identity, transpose, adjoint)
             @test Matrix(transform(LK)) ≈ transform(Matrix(LK)) ≈ transform(K)


### PR DESCRIPTION
This treats vectors upon wrapping in `LinearMap` like a column matrix, without reshaping however. This allows to easily represent rank-1 operators as `v ⊗ w'` with optimal performance.