### PR TITLE
Fix performance issue when RHS is a Matrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinearMaps"
 uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
-version = "3.2.1"
+version = "3.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/LinearMaps.jl
+++ b/src/LinearMaps.jl
@@ -213,11 +213,11 @@ end
 # the following is of interest in, e.g., subspace-iteration methods
 function mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix)
     check_dim_mul(Y, A, X)
-    return _generic_mapmat_mul!(Y, A, X)
+    return _unsafe_mul!(Y, A, X)
 end
 function mul!(Y::AbstractMatrix, A::LinearMap, X::AbstractMatrix, α::Number, β::Number)
     check_dim_mul(Y, A, X)
-    return _generic_mapmat_mul!(Y, A, X, α, β)
+    return _unsafe_mul!(Y, A, X, α, β)
 end
 
 function _generic_mapmat_mul!(Y, A, X, α=true, β=false)
@@ -235,6 +235,9 @@ _unsafe_mul!(y, A::MapOrMatrix, x) = mul!(y, A, x)
 _unsafe_mul!(y, A::AbstractMatrix, x, α, β) = mul!(y, A, x, α, β)
 function _unsafe_mul!(y::AbstractVecOrMat, A::LinearMap, x::AbstractVector, α, β)
     return _generic_mapvec_mul!(y, A, x, α, β)
+end
+function _unsafe_mul!(y::AbstractMatrix, A::LinearMap, x::AbstractMatrix)
+    return _generic_mapmat_mul!(y, A, x)
 end
 function _unsafe_mul!(y::AbstractMatrix, A::LinearMap, x::AbstractMatrix, α, β)
     return _generic_mapmat_mul!(y, A, x, α, β)


### PR DESCRIPTION
Before this patch, `mul!` would incorrectly call `_generic_mapmat_mul!` instead of `_unsafe_mul!` in cases when the RHS was a matrix.

This problem lead to huge performance penalties in all cases where the LinearMap acts more efficiently on a matrix than on the individual columns.

```
using LinearMaps
using BenchmarkTools
using LinearAlgebra
A = randn(10000,1000);
AL = LinearMap(A);
B = randn(1000,1000);
C = zeros(size(A,1), size(B,2));
```

Before patch:
```
julia> @btime mul!($C,$A,$B);
  139.193 ms (0 allocations: 0 bytes)

julia> @btime mul!($C,$AL,$B);
  2.812 s (0 allocations: 0 bytes)
```

After patch:
```
julia> @btime mul!($C,$A,$B);
  142.395 ms (0 allocations: 0 bytes)

julia> @btime mul!($C,$AL,$B);
  147.012 ms (0 allocations: 0 bytes)
```