### PR TITLE
Improve specific kron case

### DIFF
--- a/src/kronecker.jl
+++ b/src/kronecker.jl
@@ -141,7 +141,12 @@ end
     mb, nb = size(B)
     X = reshape(x, (nb, na))
     Y = reshape(y, (mb, ma))
-    if nb*ma < mb*na
+    if B isa UniformScalingMap
+        # the following is (maybe due to the reshape?) faster than
+        # _unsafe_mul!(Y, B * X, At.lmap)
+        _unsafe_mul!(Y, X, At.lmap)
+        lmul!(B.λ, y)
+    elseif nb*ma <= mb*na
         _unsafe_mul!(Y, B, X * At.lmap)
     else
         _unsafe_mul!(Y, Matrix(B*X), At.lmap)

--- a/src/uniformscalingmap.jl
+++ b/src/uniformscalingmap.jl
@@ -39,8 +39,16 @@ Base.:(*)(α::RealOrComplex, J::UniformScalingMap) = UniformScalingMap(α * J.λ
 Base.:(*)(J::UniformScalingMap, α::RealOrComplex) = UniformScalingMap(J.λ * α, size(J))
 
 # multiplication with vector
-Base.:(*)(A::UniformScalingMap, x::AbstractVector) =
-    length(x) == A.M ? A.λ * x : throw(DimensionMismatch("*"))
+Base.:(*)(J::UniformScalingMap, x::AbstractVector) =
+    length(x) == J.M ? J.λ * x : throw(DimensionMismatch("*"))
+# multiplication with matrix
+Base.:(*)(J::UniformScalingMap, B::AbstractMatrix) =
+    size(B, 1) == J.M ? J.λ * LinearMap(B) : throw(DimensionMismatch("*"))
+Base.:(*)(A::AbstractMatrix, J::UniformScalingMap) =
+    size(A, 2) == J.M ? LinearMap(A) * J.λ : throw(DimensionMismatch("*"))
+# disambiguation
+Base.:(*)(xc::LinearAlgebra.AdjointAbsVec, J::UniformScalingMap) = xc * J.λ
+Base.:(*)(xt::LinearAlgebra.TransposeAbsVec, J::UniformScalingMap) = xt * J.λ
 
 # multiplication with vector/matrix
 for (In, Out) in ((AbstractVector, AbstractVecOrMat), (AbstractMatrix, AbstractMatrix))

--- a/test/kronecker.jl
+++ b/test/kronecker.jl
@@ -66,7 +66,19 @@ using Test, LinearMaps, LinearAlgebra, SparseArrays
         @test Matrix(@inferred K*K) ≈ kron(A, B)*kron(A, B)
         A = rand(3, 2); B = rand(4, 3)
         @test Matrix(kron(LinearMap(A), B, [A A])*kron(LinearMap(A), B, A')) ≈ kron(A, B, [A A])*kron(A, B, A')
-    end
+
+        m = 3
+        A = rand(m, m)
+        S = sparse(I, m, m)
+        J = LinearMap(I, m)
+        v = rand(m^3)
+        for (K, M) in ((⊗(A, J, J), kron(A, S, S)),
+                       (⊗(J, A, J), kron(S, A, S)),
+                       (⊗(J, J, A), kron(S, S, A)))
+            @test K * v ≈ M * v
+            @test Matrix(K) ≈ M
+        end
+     end
 
     @testset "Kronecker sum" begin
         for elty in (Float64, ComplexF64)

--- a/test/left.jl
+++ b/test/left.jl
@@ -70,4 +70,7 @@ end
     @test left_tester(W)
     @test left_tester(W')
     @test left_tester(transpose(W))
+    
+    J = LinearMap(I, 5) # UniformScalingMap
+    @test left_tester(J)
 end

--- a/test/uniformscalingmap.jl
+++ b/test/uniformscalingmap.jl
@@ -48,4 +48,8 @@ using Test, LinearMaps, LinearAlgebra, BenchmarkTools
     end
     X = rand(10, 10); Y = similar(X)
     @test mul!(Y, Id, X) == X
+    @test Id*X isa LinearMap
+    @test X*Id isa LinearMap
+    @test Matrix(Id*X) == X
+    @test Matrix(X*Id) == X
 end


### PR DESCRIPTION
I noticed an interesting application for Kronecker products in https://github.com/MKAbdElrahman/LazyFDFD, where certain differential operators are discretized via finite-differencing. This is relevant for Kronecker products of 3 maps, two of which are identity maps and the third is a (wrapped) matrix in either the first, the second or the third slot. This PR pushes the case `⊗(J, A, J)`to the level of the other two versions.