### PR TITLE
Adjust to the fact that `similar(v)` does not allocate

### DIFF
--- a/test/blockmap.jl
+++ b/test/blockmap.jl
@@ -290,7 +290,7 @@ using LinearMaps: FiveArg
                 @test mul!(copy(v), LinearMap(transform(L)), u, α, β) ≈ transform(M)*u*α + v*β
                 if transform != adjoint
                     transL = transform(L)
-                    alloc = @allocated similar(v)
+                    alloc = sizeof(v) + 64
                     if L == L2 && α != false
                         @test_broken (@allocated mul!(v, transL, u, α, β)) <= alloc
                     else

--- a/test/functionmap.jl
+++ b/test/functionmap.jl
@@ -87,7 +87,7 @@ using Test, LinearMaps, LinearAlgebra
             @test mul!(copy(v), LinearMap(transform(CS!)), u, α, β) ≈ transform(M)*u*α + v*β
             if transform != transpose
                 transCS! = transform(CS!)
-                alloc = @allocated similar(v)
+                alloc = sizeof(v) + 64
                 @test (@allocated mul!(v, transCS!, u, α, β)) <= alloc
             end
         end

--- a/test/linearcombination.jl
+++ b/test/linearcombination.jl
@@ -12,7 +12,7 @@ using LinearMaps: FiveArg, LinearMapTuple, LinearMapVector, FunctionMap
     mul!(u, CS!, v)
     @test (@allocated mul!(u, CS!, v)) == 0
     n = 10
-    alloc = @allocated similar(v)
+    alloc = sizeof(v) + 64
     Loop = @inferred CS + CS + CS
     @test Loop * v ≈ 3cumsum(v)
     @test (CS + CR + CS) * v ≈ 3cumsum(v)
@@ -60,7 +60,7 @@ using LinearMaps: FiveArg, LinearMapTuple, LinearMapVector, FunctionMap
     @test occursin("10×10 $LinearMaps.LinearCombination{$(eltype(L))}", sprint((t, s) -> show(t, "text/plain", s), L+CS!))
     @test mul!(u, L, v) ≈ n * cumsum(v)
     @test mul!(u, Lv, v) ≈ n * cumsum(v)
-    alloc = @allocated similar(u)
+    alloc = sizeof(u) + 64
     mul!(u, L, v, 2, 2)
     @test (@allocated mul!(u, L, v, 2, 2)) <= alloc
     mul!(u, Lv, v, 2, 2)

--- a/test/scaledmap.jl
+++ b/test/scaledmap.jl
@@ -104,7 +104,7 @@ using Test, LinearMaps, LinearAlgebra
     for (A, alloc) in ((A0, 1), (A1, 0), (B0, 1), (B1, 0), (A0', 3), (A1', 0), (B0', 3), (B1', 0))
         x = rand(N)
         y = similar(x)
-        allocsize = @allocated similar(y)
+        allocsize = sizeof(y)+72
         mul!(y, A, x)
         @test (@allocated mul!(y, A, x)) == alloc*allocsize
     end


### PR DESCRIPTION
The numbers are adhoc, but modelled after what I saw on older Julia versions. This became necessary since on v1.12, `@allocated similar(v)` returns zero and hence is no model for the allocations happening inside `mul!`.